### PR TITLE
Prepare fixes

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -8,32 +8,32 @@ REFS=$ROOT
 BASE="$ROOT"
 
 # Needed to build things.
-sudo apt install -y git build-essential ccache python-dev python3-dev unzip
+sudo apt-get install -y git build-essential ccache python-dev python3-dev unzip
 
 # Needed to install python2 pip
-sudo apt install -y curl
+sudo apt-get install -y curl
 
 # Needed by renpy-build itself.
-sudo apt install -y python3-jinja2
+sudo apt-get install -y python3-jinja2
 
 # Needed by sysroot.
-sudo apt install -y debootstrap qemu-user-static
+sudo apt-get install -y debootstrap qemu-user-static
 
 # Needed by gcc.
-sudo apt install -y libgmp-dev libmpfr-dev libmpc-dev
+sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev
 
 # Needed by hostpython.
-sudo apt install -y libssl-dev libbz2-dev
+sudo apt-get install -y libssl-dev libbz2-dev
 
 # Needed for windows.
-sudo apt install -y mingw-w64 autoconf
+sudo apt-get install -y mingw-w64 autoconf
 
 # Needed for mac
 sudo apt install -y cmake clang libxml2-dev llvm
 
 
 # Install the standard set of packages needed to build Ren'Py.
-sudo apt install -y \
+sudo apt-get install -y \
     python-dev libavcodec-dev libavformat-dev \
     libavresample-dev libswresample-dev libswscale-dev libfreetype6-dev libglew1.6-dev \
     libfribidi-dev libsdl2-dev libsdl2-image-dev libsdl2-gfx-dev \

--- a/prepare.sh
+++ b/prepare.sh
@@ -8,7 +8,7 @@ REFS=$ROOT
 BASE="$ROOT"
 
 # Needed to build things.
-sudo apt install -y git buld-essential ccache python-dev python3-dev unzip
+sudo apt install -y git build-essential ccache python-dev python3-dev unzip
 
 # Needed to install python2 pip
 sudo apt install -y curl
@@ -17,13 +17,13 @@ sudo apt install -y curl
 sudo apt install -y python3-jinja2
 
 # Needed by sysroot.
-apt install -y debootstrap qemu-user-static
+sudo apt install -y debootstrap qemu-user-static
 
 # Needed by gcc.
 sudo apt install -y libgmp-dev libmpfr-dev libmpc-dev
 
 # Needed by hostpython.
-sudo apt install -y libssl-dev libbz2-dev lib
+sudo apt install -y libssl-dev libbz2-dev
 
 # Needed for windows.
 sudo apt install -y mingw-w64 autoconf
@@ -58,7 +58,4 @@ VENV="$ROOT/tmp/virtualenv.py2"
 export RENPY_DEPS_INSTALL=/usr::/usr/lib/x86_64-linux-gnu/
 
 . $BASE/nightly/git.sh
-
-cp /mnt/ab/renpy-build/nightly/python.sh nightly
-
 . $BASE/nightly/python.sh


### PR DESCRIPTION
- Fixed typo in `build-essential`
- Added missed `sudo`
- Removed non-existant `lib` package
- Removed reference to external `python.sh`
- Switched `apt` to `apt-get` - the latter is recommended for scripts, see `man 8 apt`