### PR TITLE
Minor fixes for automated build runs

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -29,7 +29,7 @@ sudo apt-get install -y libssl-dev libbz2-dev
 sudo apt-get install -y mingw-w64 autoconf
 
 # Needed for mac
-sudo DEBIAN_FRONTEND=noninteractive apt install -y cmake clang libxml2-dev llvm
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake clang libxml2-dev llvm
 
 
 # Install the standard set of packages needed to build Ren'Py.

--- a/prepare.sh
+++ b/prepare.sh
@@ -31,6 +31,9 @@ sudo apt-get install -y mingw-w64 autoconf
 # Needed for mac
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake clang libxml2-dev llvm
 
+# Needed for web
+sudo apt-get install -y quilt
+
 
 # Install the standard set of packages needed to build Ren'Py.
 sudo apt-get install -y \

--- a/prepare.sh
+++ b/prepare.sh
@@ -29,7 +29,7 @@ sudo apt-get install -y libssl-dev libbz2-dev
 sudo apt-get install -y mingw-w64 autoconf
 
 # Needed for mac
-sudo apt install -y cmake clang libxml2-dev llvm
+sudo DEBIAN_FRONTEND=noninteractive apt install -y cmake clang libxml2-dev llvm
 
 
 # Install the standard set of packages needed to build Ren'Py.


### PR DESCRIPTION
In a fresh installation of Ubuntu 20.04 (docker container), the execution of prepare.sh script (at this [step](https://github.com/renpy/renpy-build/blob/master/prepare.sh#L32)) stalls with an input prompt asking to select a geographic area (to configure tzdata, which is a transitive package dependency):

```
Selecting previously unselected package llvm-10-dev.
Preparing to unpack .../41-llvm-10-dev_1%3a10.0.0-4ubuntu1_amd64.deb ...
Unpacking llvm-10-dev (1:10.0.0-4ubuntu1) ...
Setting up libncurses-dev:amd64 (6.2-0ubuntu2) ...
Setting up libgc1c2:amd64 (1:7.6.4-0.4ubuntu1) ...
Setting up libyaml-0-2:amd64 (0.2.2-1) ...
Setting up python3-yaml (5.3.1-1) ...
Setting up libobjc4:amd64 (10-20200411-0ubuntu1) ...
Setting up libffi-dev:amd64 (3.3-4) ...
Setting up tzdata (2020a-0ubuntu0.20.04) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration questions will narrow this down by presenting a list
of cities, representing the time zones in which they are located.

  1. Africa   3. Antarctica  5. Arctic  7. Atlantic  9. Indian    11. SystemV  13. Etc
  2. America  4. Australia   6. Asia    8. Europe    10. Pacific  12. US
Geographic area: 
Progress: [ 57%] [###############################################################................................................]
```

In order to allow the build process to proceed automatically without any interactive prompts, I request a small change to set the environment variable `DEBIAN_FRONTEND=noninteractive` during this step.

Reference: https://techoverflow.net/2019/05/18/how-to-fix-configuring-tzdata-interactive-input-when-building-docker-images/