### PR TITLE
Use zip file for the Python modules

### DIFF
--- a/runtime/librenpython2.c
+++ b/runtime/librenpython2.c
@@ -131,12 +131,12 @@ static void find_python_home(const char *p) {
 
 
 #ifdef WINDOWS
-    if (exists(p, "\\lib\\python2.7\\site.pyo") || exists(p, "\\lib\\python27.zip")) {
+    if (exists(p, "\\lib\\python27.zip") || exists(p, "\\lib\\python2.7\\site.pyo")) {
         found = 1;
         Py_SetPythonHome(join(p, NULL));
     }
 #else
-    if (exists(p, "/lib/python2.7/site.pyo") || exists(p, "/lib/python27.zip")) {
+    if (exists(p, "/lib/python27.zip") || exists(p, "/lib/python2.7/site.pyo")) {
         found = 1;
         Py_SetPythonHome(join(p, NULL));
     }

--- a/tasks/python2.py
+++ b/tasks/python2.py
@@ -7,8 +7,10 @@ version = "2.7.18"
 def annotate(c):
     if c.python == "2":
         c.var("pythonver", "python2.7")
+        c.var("pythonver_nodot", "python27")
     else:
         c.var("pythonver", "python3.8")
+        c.var("pythonver_nodot", "python38")
 
     c.include("{{ install }}/include/{{ pythonver }}")
 


### PR DESCRIPTION
Python supports loading modules from zip file with `zipimport` module.  

With these changes, 407 files have been combined into 1 file, improving performance when doing transfers (especially on Windows due to poor NTFS performance and filesystem hooks)  
Also, due to zlib compression, even less space is used.  