### PR TITLE
Use Python 2.7 get-pip url

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -50,7 +50,7 @@ mkdir -p "$BASE/tmp"
 GET_PIP="$ROOT/tmp/get-pip.py"
 
 if [ ! -e $GET_PIP ]; then
-    curl https://bootstrap.pypa.io/2.7/get-pip.py -o $GET_PIP
+    curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o $GET_PIP
     sudo python2 $GET_PIP
 fi
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -50,7 +50,7 @@ mkdir -p "$BASE/tmp"
 GET_PIP="$ROOT/tmp/get-pip.py"
 
 if [ ! -e $GET_PIP ]; then
-    curl https://bootstrap.pypa.io/get-pip.py -o $GET_PIP
+    curl https://bootstrap.pypa.io/2.7/get-pip.py -o $GET_PIP
     sudo python2 $GET_PIP
 fi
 


### PR DESCRIPTION
Use the 2.7 get-pip as recommended by the current script at https://bootstrap.pypa.io/get-pip.py

```
ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/2.7/get-pip.py instead
```