### PR TITLE
Containerize the build environment.

### DIFF
--- a/CONTAINER_BUILD.md
+++ b/CONTAINER_BUILD.md
@@ -1,0 +1,40 @@
+# Building with Docker
+TODO
+
+# Building with Podman
+Building using containers makes it easier to create and tear down the build environment.
+Currently only Podman is tested though it may work on Docker.
+Though, running Docker on Windows will most likely not work.
+
+The end goal of this container is to give you a bash shell that you can use to run the build commands.
+This way you can easily tear down the build environment and reproduce it.
+
+## Mounts
+This container should be ran with a volume mount to your renpy-build directory.
+This can be done using the `-v` parameter.
+
+## Caviats
+In podman you can not build renpy under an unprivlaged rootless container.
+To build renpy with podman and use your local repos, the image must be built as root.
+Remember to change the UID for the container user to match your non root user to allow volume mounts.
+
+## Building with Podman
+This is an example of a typical build path process.
+
+```
+# podman build -t renpy_build .
+
+"This runs the container and drops you into a shell as the rb user with renpy-build mounted"
+# podman run --name renpy_build -i --privileged -v /path/to/renpy-build/:/renpy-build -t renpy_build /bin/bash
+
+$ cd renpy-build
+
+$ ./prepare.sh
+
+$ source tmp/virtualenv.py2/bin/activate
+
+"Build for linux x86_64"
+$ ./build.py --arch x86_64 --platform linux
+```
+
+Once your build is done you can find the output in the path that you mounted.

--- a/CONTAINER_BUILD.rst
+++ b/CONTAINER_BUILD.rst
@@ -1,7 +1,10 @@
-# Building with Docker
+Building with Docker
+============
 TODO
 
-# Building with Podman
+Building with Podman
+============
+
 Building using containers makes it easier to create and tear down the build environment.
 Currently only Podman is tested though it may work on Docker.
 Though, running Docker on Windows will most likely not work.
@@ -9,32 +12,35 @@ Though, running Docker on Windows will most likely not work.
 The end goal of this container is to give you a bash shell that you can use to run the build commands.
 This way you can easily tear down the build environment and reproduce it.
 
-## Mounts
-This container should be ran with a volume mount to your renpy-build directory.
-This can be done using the `-v` parameter.
+Mounts
+-------------
 
-## Caviats
+This container should be ran with a volume mount to your renpy-build directory.
+This can be done using the ``-v`` parameter.
+
+Caveats
+-------------
 In podman you can not build renpy under an unprivlaged rootless container.
 To build renpy with podman and use your local repos, the image must be built as root.
 Remember to change the UID for the container user to match your non root user to allow volume mounts.
 
-## Building with Podman
+Building with Podman
+-------------
+
 This is an example of a typical build path process.
 
-```
-# podman build -t renpy_build .
-
-"This runs the container and drops you into a shell as the rb user with renpy-build mounted"
-# podman run --name renpy_build -i --privileged -v /path/to/renpy-build/:/renpy-build -t renpy_build /bin/bash
-
-$ cd renpy-build
-
-$ ./prepare.sh
-
-$ source tmp/virtualenv.py2/bin/activate
-
-"Build for linux x86_64"
-$ ./build.py --arch x86_64 --platform linux
-```
+        # podman build -t renpy_build .
+        
+        "This runs the container and drops you into a shell as the rb user with renpy-build mounted"
+        # podman run --name renpy_build -i --privileged -v /path/to/renpy-build/:/renpy-build -t renpy_build /bin/bash
+        
+        $ cd renpy-build
+        
+        $ ./prepare.sh
+        
+        $ source tmp/virtualenv.py2/bin/activate
+        
+        "Build for linux x86_64"
+        $ ./build.py --arch x86_64 --platform linux
 
 Once your build is done you can find the output in the path that you mounted.

--- a/CONTAINER_BUILD.rst
+++ b/CONTAINER_BUILD.rst
@@ -33,6 +33,7 @@ This is an example of a typical build path process.
         (host) # podman build -t renpy_build .
         
         "This runs the container and drops you into a shell as the rb user with renpy-build mounted"
+        
         (host) # podman run --name renpy_build -i --privileged -v /path/to/renpy-build/:/renpy-build -t renpy_build /bin/bash
         
         (container) $ cd renpy-build
@@ -42,6 +43,7 @@ This is an example of a typical build path process.
         (container) $ source tmp/virtualenv.py2/bin/activate
         
         "Build for linux x86_64"
+        
         (container) $ ./build.py --arch x86_64 --platform linux
 
 Once your build is done you can find the output in the path that you mounted.

--- a/CONTAINER_BUILD.rst
+++ b/CONTAINER_BUILD.rst
@@ -1,6 +1,7 @@
 Building with Docker
 ============
-TODO
+Building with docker is similar to Podman.
+Just replace podman with docker in the commands and remove ``--privileged``
 
 Building with Podman
 ============
@@ -29,18 +30,18 @@ Building with Podman
 
 This is an example of a typical build path process.
 
-        # podman build -t renpy_build .
+        (host) # podman build -t renpy_build .
         
         "This runs the container and drops you into a shell as the rb user with renpy-build mounted"
-        # podman run --name renpy_build -i --privileged -v /path/to/renpy-build/:/renpy-build -t renpy_build /bin/bash
+        (host) # podman run --name renpy_build -i --privileged -v /path/to/renpy-build/:/renpy-build -t renpy_build /bin/bash
         
-        $ cd renpy-build
+        (container) $ cd renpy-build
         
-        $ ./prepare.sh
+        (container) $ ./prepare.sh
         
-        $ source tmp/virtualenv.py2/bin/activate
+        (container) $ source tmp/virtualenv.py2/bin/activate
         
         "Build for linux x86_64"
-        $ ./build.py --arch x86_64 --platform linux
+        (container) $ ./build.py --arch x86_64 --platform linux
 
 Once your build is done you can find the output in the path that you mounted.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:20.04
+
+RUN echo "Updating Repos"; apt update
+
+RUN echo "Installing sudo to allow scripts to work"; apt-get install -y sudo
+
+RUN echo "Making renpy_build directory"; mkdir /renpy-build
+
+# Needed to build things.
+RUN apt-get install -y git build-essential ccache python-dev-is-python2 python3-dev unzip
+
+# Needed to install python2 pip
+RUN apt-get install -y curl
+
+# Needed by renpy-build itself.
+RUN apt-get install -y python3-jinja2
+
+# Needed by sysroot.
+RUN apt-get install -y debootstrap qemu-user-static
+
+# Needed by gcc.
+RUN apt-get install -y libgmp-dev libmpfr-dev libmpc-dev
+
+# Needed by hostpython.
+RUN apt-get install -y libssl-dev libbz2-dev
+
+# Needed for windows.
+RUN apt-get install -y mingw-w64 autoconf
+
+# Needed for mac
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y cmake clang libxml2-dev llvm
+
+# Needed for web
+RUN apt-get install -y quilt
+
+# Install the standard set of packages needed to build Ren'Py.
+RUN apt-get install -y \
+    python-dev-is-python2 libavcodec-dev libavformat-dev \
+    libavresample-dev libswresample-dev libswscale-dev libfreetype6-dev libglew1.6-dev \
+    libfribidi-dev libsdl2-dev libsdl2-image-dev libsdl2-gfx-dev \
+    libsdl2-mixer-dev libsdl2-ttf-dev libjpeg-turbo8-dev
+
+# Add clang to the image itself
+COPY "prebuilt/clang_rt.tar.gz" /tmp/clang_rt.tar.gz
+
+RUN tar xzf "/tmp/clang_rt.tar.gz" -C /usr/lib/clang/10/lib/
+
+RUN rm /tmp/clang_rt.tar.gz
+
+RUN useradd --uid 1000 -m "rb"
+
+# add rb to the sudoers so scripts will run
+RUN printf "rb ALL = (ALL) NOPASSWD : ALL\n" >> /etc/sudoers.d/rb
+
+USER rb
+
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o /tmp/get-pip.py
+
+RUN sudo python2 /tmp/get-pip.py
+
+RUN pip2 install virtualenv
+
+CMD "/usr/bin/bash"
+


### PR DESCRIPTION
I am making it so RenPy can be built inside a podman/docker container. So far I've had luck with a root privileged podman container. This build environment will be treated as a shell for building RenPy with the container having all the required build tools and versions.

This should also be easily adaptable into automated builds.

This most likely will not work on docker in Windows and potentially macOS as well.

The goal if this is to not change any functionality in the current build scripts.

# ToDos

- [x] Create Dockerfile
- [x] Instructions on using with Podman
- [x] Instructions on using Docker