### PR TITLE
Gradle Heap Size Adjustment

### DIFF
--- a/rapt/buildlib/rapt/configure.py
+++ b/rapt/buildlib/rapt/configure.py
@@ -42,6 +42,7 @@ class Configuration(object):
         self.store = "none"
         self.update_icons = True
         self.update_always = True
+        self.heap_size = None
 
         try:
             with file(os.path.join(directory, ".android.json"), "r") as f:
@@ -79,6 +80,15 @@ def set_version(config, value):
     except:
         pass
 
+def set_heap_size(config, value, gradle_dir):
+    """
+    Sets the Java Heap Size for Gradle in gradle.properties.
+    """
+    config.heap_size = value
+
+    for open(gradle_dir, "w+") as g:
+        g.writelines(["# The setting is particularly useful for tweaking memory settings.\n", "org.gradle.jvmargs=-Xmx" + value + "g\n", "# Disable the gradle daemon, so it doesn't waste ram.\n", "org.gradle.daemon = false"])
+    
 
 def configure(interface, directory, default_name=None, default_version=None):
 
@@ -131,6 +141,26 @@ def configure(interface, directory, default_name=None, default_version=None):
 
     if not re.match(r'^[\d]+$', config.numeric_version):
         interface.fail(__("The numeric version must contain only numbers."))
+
+    if config.heap_size is None:
+        heap = open(plat.path("project/gradle.properties"), "r")
+        for line in heap:
+            if "-Xmx" in line:
+                heapVal = line
+        heap.close()
+        heapVal = heapVal.replace('-Xmx', "")
+        heapVal = heapVal.replace('g', "")
+        config.heap_size = heapVal
+
+    heap_size = interface.input(__("How much RAM do you want to allocate to Gradle?\n\nThis must be a positive number, and be between 3 to 8 GB in size."), config.heap_size)
+
+    if not re.match(r'^[\d]+$', config.heap_size):
+        interface.fail(__("The RAM size must contain only numbers."))
+
+    if int(heap_size) < 3 or int(heap_size) > 8:
+        interface.fail(__("The RAM size must be between 2-8 GB in size."))
+
+    set_heap_size(config, heap_size, plat.path("project/gradle.properties"))
 
     config.orientation = interface.choice(__("How would you like your application to be displayed?"), [
         ("sensorLandscape", __("In landscape orientation.")),

--- a/rapt/buildlib/rapt/configure.py
+++ b/rapt/buildlib/rapt/configure.py
@@ -86,7 +86,7 @@ def set_heap_size(config, value, gradle_dir):
     """
     config.heap_size = value
 
-    for open(gradle_dir, "w+") as g:
+    with open(gradle_dir, "w+") as g:
         g.writelines(["# The setting is particularly useful for tweaking memory settings.\n", "org.gradle.jvmargs=-Xmx" + value + "g\n", "# Disable the gradle daemon, so it doesn't waste ram.\n", "org.gradle.daemon = false"])
     
 
@@ -145,11 +145,11 @@ def configure(interface, directory, default_name=None, default_version=None):
     if config.heap_size is None:
         heap = open(plat.path("project/gradle.properties"), "r")
         for line in heap:
-            if "-Xmx" in line:
+            if "org.gradle.jvmargs" in line:
                 heapVal = line
         heap.close()
-        heapVal = heapVal.replace('-Xmx', "")
-        heapVal = heapVal.replace('g', "")
+        heapVal = heapVal.replace('org.gradle.jvmargs=-Xmx', "")
+        heapVal = heapVal.replace('g\n', "")
         config.heap_size = heapVal
 
     heap_size = interface.input(__("How much RAM do you want to allocate to Gradle?\n\nThis must be a positive number, and be between 3 to 8 GB in size."), config.heap_size)

--- a/rapt/buildlib/rapt/configure.py
+++ b/rapt/buildlib/rapt/configure.py
@@ -152,13 +152,10 @@ def configure(interface, directory, default_name=None, default_version=None):
         heapVal = heapVal.replace('g\n', "")
         config.heap_size = heapVal
 
-    heap_size = interface.input(__("How much RAM do you want to allocate to Gradle?\n\nThis must be a positive number, and be between 3 to 8 GB in size."), config.heap_size)
+    heap_size = interface.input(__("How much RAM do you want to allocate to Gradle?\n\nThis must be a positive integer number."), config.heap_size)
 
     if not re.match(r'^[\d]+$', config.heap_size):
         interface.fail(__("The RAM size must contain only numbers."))
-
-    if int(heap_size) < 3 or int(heap_size) > 8:
-        interface.fail(__("The RAM size must be between 2-8 GB in size."))
 
     set_heap_size(config, heap_size, plat.path("project/gradle.properties"))
 


### PR DESCRIPTION
From renpy/renpy PR #2734

## Issue
From last PR, due to a fixed Gradle RAM size, projects greater than 500 MB may experience a `java.lang.OutOfMemory` error when building.

## Solution
As discussed in said PR, this PR adds a Gradle heap size field in `configure.py` or the Configure button in the Android screen that allows project makers to adjust this value automatically.

![image](https://user-images.githubusercontent.com/40864681/112078478-816b4b80-8b4c-11eb-921e-72de7aa00e5a.png)

## Code Explanation
- `set_heap_size` writes the RAM value to *gradle.properties* with some comments and other code within it.
- `if config.heap_size is None` reads in the `org.gradle.jvmargs=-Xmx3g` variable when found and splits it so it reads only `3` and displays it in the prompt (or any value assigned).

This is the attempt I have done though you can base it off it or ask for fixes that I can apply as part of this PR.