### PR TITLE
Android .gz handling counter-measures

### DIFF
--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import time
 import zipfile
+import gzip
 import subprocess
 import hashlib
 import collections
@@ -530,6 +531,21 @@ def build(iface, directory, install=False, bundle=False, launch=False, finished=
                     new = os.path.join(dirpath, "x-" + fn)
 
                     plat.rename(old, new)
+
+                    if new[-3:] != ".gz":
+                        continue
+
+                    # AAPT unavoidably gunzips files with a .gz extension.
+                    # To prevent this we temporarily double gzip such files,
+                    # leaving AAPT to unpack them back into the original
+                    # location. /o\
+
+                    old, new = new, new + ".gz"
+
+                    with open(old, "rb") as src, gzip.open(new, "wb") as out:
+                        shutil.copyfileobj(src, out)
+
+                    os.unlink(old)
 
     iface.background(make_assets)
 


### PR DESCRIPTION
AAPT unavoidably gunzips files with a .gz extension as part of it's
packaging step, decompressing their contents and dropping the .gz from
their file name.

While it's true that zipping an already compressed file isn't the most
ideal thing to do, unfortunately the result for creators is a missing
file due to the name change, and a need to know about this quirk as well
as introduce an Android specific code path to handle it.

In order to avoid this scenario, prior to the packaging step we
temporarily double gzip affected files, then leave AAPT to unpack them
back into the original location.

An alternative, and indeed the initially suggested, approach would have
been to alter the `.gz` extension, similar to the way `assets` are given
the `x-` prefix, however this would have required more comprehensive
changes both here and in Ren'Py proper (to correctly map back the
change). Ultimately, this seemed like a suitably less invasive approach
to cover what is undeniably an, even if annoying, very rare corner case.