### PR TITLE
Update git.sh

### DIFF
--- a/nightly/git.sh
+++ b/nightly/git.sh
@@ -8,7 +8,12 @@ update () {
         popd
     else
         if [ -e "$REFS/$2/.git" ]; then
-            git clone $1 "$BASE/$2" --reference "$REFS/$2"
+            if [ $REFS = $BASE ]; then
+                git reset --hard
+                git pull
+            else
+                git clone $1 "$BASE/$2" --reference "$REFS/$2"
+            fi
         else
             git clone $1 "$BASE/$2"
         fi


### PR DESCRIPTION
Makes it possible to use this repo as a submodule and not a root git project

This shouldn't disrupt the case when you are using a cache folder ($REFS != $BASE), but still want to use a .git file and not a .git folder.