### PR TITLE
Avoid leaking site.py into builds

### DIFF
--- a/tasks/pythonlib.py
+++ b/tasks/pythonlib.py
@@ -263,6 +263,7 @@ def python2(c):
             f.write("renpy_build_official = True\n")
 
     c.run("{{ hostpython }} -OO -m compileall {{ distlib }}/{{ pythonver }}/site.py")
+    c.unlink("{{ distlib }}/{{ pythonver }}/site.py")
 
     c.run("mkdir -p {{ distlib }}/{{ pythonver }}/lib-dynload")
     with open(c.path("{{ distlib }}/{{ pythonver }}/lib-dynload/empty.txt"), "w") as f:
@@ -570,6 +571,7 @@ def python3(c):
             f.write("renpy_build_official = True\n")
 
     c.run("{{ hostpython }} -m compileall -b {{ distlib }}/{{ pythonver }}/site.py")
+    c.unlink("{{ distlib }}/{{ pythonver }}/site.py")
 
     c.run("mkdir -p {{ distlib }}/{{ pythonver }}/lib-dynload")
     with open(c.path("{{ distlib }}/{{ pythonver }}/lib-dynload/empty.txt"), "w") as f:


### PR DESCRIPTION
Intent here is to ship the bytecode version only, inline with the rest of pythonlib, and so avoid recompilations which leak into the SDK and eventually games,