### PR TITLE
Fix: Android icons did not work properly

### DIFF
--- a/rapt/buildlib/rapt/iconmaker.py
+++ b/rapt/buildlib/rapt/iconmaker.py
@@ -102,7 +102,7 @@ class IconMaker(object):
             pass
 
         # Did the user provide the file?
-        src = os.path.join(self.directory, "android-{}-{}.png".format(name, dpi))
+        src = os.path.join(self.directory, "android-{}_{}.png".format(name, dpi))
 
         if os.path.exists(src):
             shutil.copy(src, dst)


### PR DESCRIPTION
In the documentation, it is mentioned that the icon naming format is `android-icon_foreground.png` and `android-icon_background.png`.
However, in the code, the format for the loaded images was `android-icon-foreground.png`. This PR fixes the issue, and makes it behave as documented.