### PR TITLE
rapt: Prevent clobbering shadowed "x-*" assets

### DIFF
--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -586,7 +586,11 @@ def build(iface, directory, install=False, bundle=False, launch=False, finished=
             # them.
             for dirpath, dirnames, filenames in os.walk(assets, topdown=False):
 
-                for fn in filenames + dirnames:
+                # Sort names longest to shortest to ensure that adding the "x-"
+                # prefix will not overwrite an asset before it has been moved.
+                names = sorted(dirnames + filenames, key=len, reverse=True)
+
+                for fn in names:
                     if fn[0] == ".":
                         continue
 


### PR DESCRIPTION
In a scenario where `foo` and `x-foo` both exist, it was previously
possible for `foo` to be moved to `x-foo` before `x-foo` had been moved
to `x-x-foo`, with the result that the original `x-foo` went missing
having been overwritten.

By reverse sorting base names by length, we ensure that `x-foo` will
always be renamed before `foo`, avoiding the potential for overwriting
such shadowed assets.

Fixes: https://github.com/renpy/renpy/issues/3902