### PR TITLE
Link source commit from nightly page

### DIFF
--- a/nightly/rev.sh
+++ b/nightly/rev.sh
@@ -1,10 +1,31 @@
-pushd $BASE/renpy
-
 # Figure out a reasonable version name.
-# REV=$(git rev-parse --short HEAD)
-# BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
 export RENPY_7_NIGHTLY="7-nightly-$(date +%Y-%m-%d)"
 export RENPY_8_NIGHTLY="8-nightly-$(date +%Y-%m-%d)"
 
+# Capture current renpy revision.
+pushd $BASE/renpy
+RENPY_REV=$(git log -n1 --pretty='"%H", "%h"' HEAD)
 popd
+
+# Capture current pygame_sdl2 revision.
+pushd $BASE/pygame_sdl2
+PYGAME_SDL2_REV=$(git log -n1 --pretty='"%H", "%h"' HEAD)
+popd
+
+# Capture current renpyweb revision.
+pushd $BASE/renpyweb
+RENPYWEB_REV=$(git log -n1 --pretty='"%H", "%h"' HEAD)
+popd
+
+# Capture current renpy-build revision.
+RENPY_BUILD_REV=$(git log -n1 --pretty='"%H", "%h"' HEAD)
+
+# Write revisions to file, renpy-build should always be last.
+cat > vcs.json <<-EOF
+[
+  ["renpy",       $RENPY_REV],
+  ["pygame_sdl2", $PYGAME_SDL2_REV],
+  ["renpyweb",    $RENPYWEB_REV],
+  ["renpy-build", $RENPY_BUILD_REV]
+]
+EOF

--- a/nightly/templates/nightly.html
+++ b/nightly/templates/nightly.html
@@ -33,8 +33,15 @@
       <p>
       This build is temporary, it will be removed from the web after a few
       days.
+      {% if vcs|length > 2 %}
+      It was built from
+      {%- for src in vcs[:-2] %}
+      <code><a href="{{ src.url }}">{{ src.text }}</a></code>,
+      {%- endfor %} and
+      <code><a href="{{ vcs[-2].url }}">{{ vcs[-2].text }}</a></code>, using
+      <code><a href="{{ vcs[-1].url }}">{{ vcs[-1].text }}</a></code>.
+      {% endif -%}
       </p>
-
 
       <h3>SDK Downloads</h3>
         <table class="table">
@@ -57,7 +64,6 @@
             </tr>
             {% endfor %}
         </table>
-
 
     </div>
 

--- a/nightly/web.sh
+++ b/nightly/web.sh
@@ -1,5 +1,16 @@
+# Try to copy VCS data to distribution directories.
+if [ -e vcs.json -a -n "$RENPY_7_NIGHTLY" -a -n "$RENPY_8_NIGHTLY" ]; then
+    mkdir -p renpy/dl/$RENPY_7_NIGHTLY/
+    cp vcs.json renpy/dl/$RENPY_7_NIGHTLY/
+
+    mkdir -p renpy/dl/$RENPY_8_NIGHTLY/
+    cp vcs.json renpy/dl/$RENPY_8_NIGHTLY/
+
+    rm vcs.json
+fi
+
 # Copy the documentation to the website.
-rm -Rf $BASE/renpy/dl/doc|| true
+rm -Rf $BASE/renpy/dl/doc || true
 cp -a $BASE/renpy/doc-web $BASE/renpy/dl/doc
 
 # Upload the nightly build to the web.


### PR DESCRIPTION
With the switch to date format for nightly versioning it's not always obvious which commit a nightly was built from (especially so on busy nights), so include that information with a link back to GitHub on the download page for easy reference.

JSON generation and jinga2 template snippet have been tested, but the end-to-end process has not, but I _think_ it's sane. 🙂