### PR TITLE
Fix building sdl2_image for web2

### DIFF
--- a/tasks/sdl2_image.py
+++ b/tasks/sdl2_image.py
@@ -27,7 +27,7 @@ def build(c: Context):
 
     c.env("LIBAVIF_LIBS", "-lavif -laom")
 
-    if c.platform == "web":
+    if c.platform == "web" and c.platform != "2":
         c.env("SDL_CFLAGS", "-sUSE_SDL=2")
         c.env("SDL_LIBS", "-sUSE_SDL=2")
 

--- a/tasks/sdl2_image.py
+++ b/tasks/sdl2_image.py
@@ -27,7 +27,7 @@ def build(c: Context):
 
     c.env("LIBAVIF_LIBS", "-lavif -laom")
 
-    if c.platform == "web" and c.platform != "2":
+    if c.platform == "web" and c.python != "2":
         c.env("SDL_CFLAGS", "-sUSE_SDL=2")
         c.env("SDL_LIBS", "-sUSE_SDL=2")
 


### PR DESCRIPTION
Building sdl2_image for web2 uses gcc instead of emcc so the "-s" switch is rejected as an error. If sdl2_image has been built for web3 before building web2 though, it is not rebuilt, so the issue does not show up.