### PR TITLE
web: Add local server executables (.bat/.sh)

### DIFF
--- a/runtime/web/run_local_server.bat
+++ b/runtime/web/run_local_server.bat
@@ -1,0 +1,24 @@
+@echo off
+
+rem Check if the 80 port is occupied
+netstat -an | find ":80 " > nul
+if %ERRORLEVEL% == 0 (
+  echo Port 80 is occupied, using port 3000 instead
+  set port=3000
+) else (
+  echo Port 80 is available
+  set port=80
+)
+
+rem Check if Python 2 or 3 is installed
+python -V 2>&1 | find "Python 2" > nul
+if %ERRORLEVEL% == 0 (
+  echo Python 2 is installed
+  start "" "cmd /c python -m SimpleHTTPServer %port%"
+) else (
+  echo Python 3 is installed
+  start "" "cmd /c python -m http.server %port%"
+)
+
+rem Open the browser
+start "" "http://localhost:%port%"

--- a/runtime/web/run_local_server.sh
+++ b/runtime/web/run_local_server.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Check if the 80 port is occupied
+if netstat -an | grep -q ":80 "; then
+  echo "Port 80 is occupied, using port 3000 instead"
+  port=3000
+else
+  echo "Port 80 is available"
+  port=80
+fi
+
+# Check if Python 2 or 3 is installed
+if command -v python2 > /dev/null 2>&1; then
+  echo "Python 2 is installed"
+  python2 -m SimpleHTTPServer $port &
+elif command -v python3 > /dev/null 2>&1; then
+  echo "Python 3 is installed"
+  python3 -m http.server $port &
+else
+  echo "Python not found"
+  exit 1
+fi
+
+# Open the browser
+xdg-open "http://localhost:$port"


### PR DESCRIPTION
This pull request adds a new feature that enables users to launch a server without relying on the Ren'Py launcher. Utilizing the built-in Python library http.server, it simplifies the process of sharing HTML files with others. Previously, the only convenient options to run generated HTML files were using the Ren'Py launcher or installing Nginx, both of which are not accessible to non-technical users. To address this issue, I have created two executable files (.bat and .sh) that will serve the current directory as an HTTP server on port 80, making it easier for everyone to share their HTML files.

.sh file needs to be tested, I don't have Linux installed to check it properly, but it should work.