### PR TITLE
Support SDK installation from command-line

### DIFF
--- a/rapt/android.py
+++ b/rapt/android.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python2.7
 
-import sys
-sys.path.insert(0, 'buildlib')
-
 import os
+import sys
+if 'rapt' in sys.modules:
+    del sys.modules['rapt']
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'buildlib'))
+
 import argparse
-import subprocess
-import pygame_sdl2
 
 import rapt.interface as interface
 import rapt.install_sdk as install_sdk
-import rapt.configure as configure
-import rapt.build as build
-import rapt.plat as plat
 
 def main():
 


### PR DESCRIPTION
At the moment, there is no command-only way to install the SDK from the command-line, which is an issue when automating Ren'Py games' releases as it makes it impossible to 'cleanly' automate Android releases on CI/CD platforms.

This PR:
* Fixes an issue with the inserted `buildlib` path when running from a directory that is not the one that contains `android.py`
* Removes unused imports
* Makes it possible to run `lib/py?-[...]/python -m rapt.android` from Ren'Py's directory to install the android SDK from the command-line on a Ren'Py install
