### PR TITLE
Ensure key.store plays nice with relative paths

### DIFF
--- a/rapt/buildlib/rapt/keys.py
+++ b/rapt/buildlib/rapt/keys.py
@@ -198,7 +198,7 @@ def update_project_keys(base):
     set_property(properties, "key.store.password", "android", replace=True)
     set_property(properties, "key.alias.password", "android", replace=True)
 
-    default_keystore = default_keystore_path(base)
+    default_keystore = os.path.abspath(default_keystore_path(base))
     set_property(properties, "key.store", default_keystore.replace("\\", "/"), replace=True)
 
     # Update the bundle properties.
@@ -209,7 +209,7 @@ def update_project_keys(base):
     set_property(properties, "key.store.password", "android", replace=True)
     set_property(properties, "key.alias.password", "android", replace=True)
 
-    bundle_keystore = bundle_keystore_path(base)
+    bundle_keystore = os.path.abspath(bundle_keystore_path(base))
     set_property(properties, "key.store", bundle_keystore.replace("\\", "/"), replace=True)
 
 


### PR DESCRIPTION
The working directory changes before signing takes place, which results in keys not being found. Avoid this by writing absolute paths into the local.properties file.