### PR TITLE
Re-Enable WASAPI support

### DIFF
--- a/tasks/sdl2.py
+++ b/tasks/sdl2.py
@@ -44,7 +44,6 @@ def build(c: Context):
         --disable-shared
         --prefix="{{ install }}"
 
-        --disable-wasapi
         --disable-render-metal
         --disable-jack
 


### PR DESCRIPTION
Enable WASAPI support in SDL, as https://github.com/renpy/renpy-build/issues/66 .