### PR TITLE
Fix RC compiler flag right in cross-compile for windows.

### DIFF
--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -114,6 +114,7 @@ def build_environment(c):
 
     c.env("CPPFLAGS", "-I{{ install }}/include")
     c.env("CFLAGS", "-O3 -I{{ install }}/include")
+    c.env("CXXFLAGS", "-O3 -L{{install}}/lib")
     c.env("LDFLAGS", "-O3 -L{{install}}/lib")
 
     c.env("PATH", "{{ host }}/bin:{{ PATH }}")

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -71,6 +71,9 @@ def llvm(c, bin="", prefix="", suffix="-15", clang_args="", use_ld=True):
 
     c.env("WINDRES", "{{llvm_bin}}{{llvm_prefix}}windres{{llvm_suffix}}")
 
+    if c.platform == "windows":
+        c.env("RC", "{{WINDRES}}")
+
 def android_llvm(c, arch):
 
     if arch == "armv7a":
@@ -109,7 +112,7 @@ def build_environment(c):
     c.var("sysroot", c.tmp / f"sysroot.{c.platform}-{c.arch}")
     c.var("build_platform", sysconfig.get_config_var("HOST_GNU_TYPE"))
 
-    c.env("CPPFLAGS", "-O3 -I{{ install }}/include")
+    c.env("CPPFLAGS", "-I{{ install }}/include")
     c.env("CFLAGS", "-O3 -I{{ install }}/include")
     c.env("LDFLAGS", "-O3 -L{{install}}/lib")
 

--- a/tasks/xz.py
+++ b/tasks/xz.py
@@ -22,5 +22,5 @@ def build(c: Context) :
     c.run("""rm -f src/common/common_w32res.rc""")
     c.run("""touch src/common/common_w32res.rc""")
 
-    c.run("""{{ make }} RC="--tag=RC {{root}}/tools/cleanwindres" """)
+    c.run("""{{ make }}""")
     c.run("""make install """)


### PR DESCRIPTION
Add RC compiler flag, which is needed for SDL2.
```makefile
# tmp/build/sdl2.windows-x86_64/SDL2-2.0.20/Makefile:779
$(objects)/version.lo: ./src/main/windows/version.rc $(objects)/.created
	$(RUN_CMD_RC)$(LIBTOOL) --mode=compile --tag=RC $(RC) -i $< -o $@
```
`-O3` is aready setting in `CFLAGS` and `CXXFLAGS`, add it in `CPPFLAGS` is useless and broken `xz`'s building.
```makefile
# tmp/build/xz.windows-x86_64/xz-5.4.2/src/liblzma/Makefile:2197
.rc.lo:
	$(LIBTOOL) --mode=compile $(RC) $(DEFS) $(DEFAULT_INCLUDES) \
		$(INCLUDES) $(liblzma_la_CPPFLAGS) $(CPPFLAGS) $(RCFLAGS) \
		-i $< -o $@
	echo > empty.c
	$(COMPILE) -c empty.c -o $(*D)/$(*F).o
# RC compiler will incorrectly treat "-O3" in "CPPFLAGS" as "--output-format=3".
```
