### PR TITLE
Fix parse errors handling for Content-Length

### DIFF
--- a/runtime/web/renpy-pre.js
+++ b/runtime/web/renpy-pre.js
@@ -357,11 +357,8 @@ Module.preRun = Module.preRun || [ ];
                 reportError("Could not load game.zip: " + response.status + " " + response.statusText);
             }
 
-            try {
-                gameZipSize = parseInt(response.headers.get('Content-Length'), 10);
-            } catch (e) {
-                // Ignore.
-            }
+            gameZipSize = parseInt(response.headers.get('Content-Length'), 10);
+            if(Number.isNaN(gameZipSize)) gameZipSize = 0;
 
             let reader = await response.body.getReader();
 


### PR DESCRIPTION
`parseInt()` returns `NaN` [when parsing failed](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#return_value), it never raises an exception as the original code expected.
`responses.headers.get()` returns `null` [when the header is not found](https://developer.mozilla.org/en-US/docs/Web/API/Headers/get#return_value), and `parseInt(null)` returns `NaN`.

That should fix #75 as [progress() is never called for game.zip when `gameZipSize` is 0](https://github.com/renpy/renpy-build/blob/15df3c9644bad2eca04b479c8671be6d8247d665/runtime/web/renpy-pre.js#L312). Of course, making sure progress() does not crash when `total` is invalid is still good to have though.