### PR TITLE
Fix fullscreen web

### DIFF
--- a/runtime/web/renpy-pre.js
+++ b/runtime/web/renpy-pre.js
@@ -899,6 +899,12 @@ Module.preRun = Module.preRun || [ ];
                 return -3
             }
             var canPerformRequests = JSEvents.canPerformEventHandlerRequests();
+
+            if (navigator.userActivation && navigator.userActivation.isActive) {
+                // Use transient activation status for browsers that support it
+                canPerformRequests = true;
+            }
+
             if (!canPerformRequests) {
                 if (strategy.deferUntilInEventHandler) {
                     JSEvents.deferCall(JSEvents_requestFullscreen, 1, [target, strategy]);

--- a/runtime/web/renpy-pre.js
+++ b/runtime/web/renpy-pre.js
@@ -907,6 +907,12 @@ Module.preRun = Module.preRun || [ ];
 
             if (!canPerformRequests) {
                 if (strategy.deferUntilInEventHandler) {
+                    if (target.requestFullscreen) {
+                        // Try requesting fullscreen mode now and only defer if the Promise fails
+                        JSEvents_requestFullscreen(target, strategy, true);
+                        return 1
+                    }
+
                     JSEvents.deferCall(JSEvents_requestFullscreen, 1, [target, strategy]);
                     return 1
                 }
@@ -915,13 +921,22 @@ Module.preRun = Module.preRun || [ ];
             return JSEvents_requestFullscreen(target, strategy)
         };
 
-        window.JSEvents_requestFullscreen = function(target, strategy) {
-            if (strategy.scaleMode != 0 || strategy.canvasResolutionScaleMode != 0) {
+        window.JSEvents_requestFullscreen = function(target, strategy, retry) {
+            if ((strategy.scaleMode != 0 || strategy.canvasResolutionScaleMode != 0) && retry !== 0) {
                 JSEvents_resizeCanvasForFullscreen(target, strategy)
             }
             if (target.requestFullscreen) {
                 target.requestFullscreen()
+                    .catch(() => {
+                        if (retry) {
+                            // Defer to next input event
+                            // (retry is set to 0 to prevent resizing the canvas again as this
+                            // erases the old canvas size with the fullscreen size)
+                            JSEvents.deferCall(JSEvents_requestFullscreen, 1, [target, strategy, 0]);
+                        }
+                    });
             } else if (target.webkitRequestFullscreen) {
+                // No result returned from webkitRequestFullscreen() (old and deprecated API)
                 target.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT)
             } else {
                 return JSEvents.fullscreenEnabled() ? -3 : -1


### PR DESCRIPTION
This PR fixes the switch to fullscreen mode which does not happen immediately on Web. The related emscripten functions are re-implemented in "renpy-pre.js" with the following changes:
* check [`navigator.userActivation.isActive`](https://developer.mozilla.org/en-US/docs/Web/API/UserActivation/isActive) on browsers that support it to know if the fullscreen request can be performed now and needs to be defer to next input event.
* always perform the fullscreen request now on browsers that implement [`requestFullScreen`](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen), and if it fails, try it again during the next input event.

Browsers that don't implement `navigator.userActivation.isActive` ([all but Firefox](https://caniuse.com/?search=isActive)) do implement `requestFullScreen` ([all but Safari on iOS](https://caniuse.com/?search=requestFullscreen)) so that should cover all recent browsers.

This PR and a related one in renpy should fix the issues in renpy/renpy#4760.