### PR TITLE
Use `ndk_version`, update NDK to 25c

### DIFF
--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -85,7 +85,7 @@ def android_llvm(c, arch):
 
     llvm(
         c,
-        bin="{{cross}}/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin",
+        bin="{{cross}}/{{ndk_version}}/toolchains/llvm/prebuilt/linux-x86_64/bin",
         prefix=f"{arch}-linux-android{ eabi }21-",
         suffix="",
         clang_args="",
@@ -100,6 +100,8 @@ def build_environment(c):
     if c.platform == "web" and c.kind not in ( "host",  "host-python", "cross" ):
         emsdk_environment(c)
 
+    if c.platform == "android":
+        c.var("ndk_version", "android-ndk-r25b")
 
     cpuccount = os.cpu_count()
 

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -101,7 +101,7 @@ def build_environment(c):
         emsdk_environment(c)
 
     if c.platform == "android":
-        c.var("ndk_version", "android-ndk-r25b")
+        c.var("ndk_version", "android-ndk-r25c")
 
     cpuccount = os.cpu_count()
 

--- a/tars/.gitignore
+++ b/tars/.gitignore
@@ -1,6 +1,6 @@
 old/
 
-android-ndk-r25b-linux.zip
+android-ndk-r25c-linux.zip
 CubismSdkForNative-4-r.6.2.zip
 iPhoneOS14.0.sdk.tar.gz
 iPhoneSimulator14.0.sdk.tar.gz

--- a/tars/README.rst
+++ b/tars/README.rst
@@ -21,7 +21,7 @@ Run ./ios_toolchains.sh /path/to/Xcode.app
 Android NDK
 -----------
 
-* android-ndk-r25b-linux.zip
+* android-ndk-r25c-linux.zip
 
 Downloaded from https://developer.android.com/ndk/downloads .
 

--- a/tasks/toolchain.py
+++ b/tasks/toolchain.py
@@ -51,13 +51,13 @@ def usrinclude(c: Context):
 @task(kind="cross", platforms="android", always=True)
 def build(c: Context):
 
-    if c.path("{{cross}}/android-ndk-r25b").exists():
+    if c.path("{{cross}}/{{ndk_version}}").exists():
         return
 
     c.clean("{{cross}}")
     c.chdir("{{cross}}")
 
-    c.run("""unzip -q {{ tars }}/android-ndk-r25b-linux.zip""")
+    c.run("""unzip -q {{ tars }}/{{ndk_version}}-linux.zip""")
 
 @task(kind="cross", platforms="mac")
 def build(c: Context):


### PR DESCRIPTION
Ndk r25c don't contain major changes compare to 25b, as [Ndk Changelog r25](https://github.com/android/ndk/wiki/Changelog-r25) says, but [https://developer.android.google.cn/ndk/downloads](https://developer.android.google.cn/ndk/downloads) provide r25c by default, r25b must be download manually.