### PR TITLE
Add missing `ndk_version` to set the default ndk version.

### DIFF
--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -85,7 +85,7 @@ def android_llvm(c, arch):
 
     llvm(
         c,
-        bin="{{cross}}/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin",
+        bin="{{cross}}/{{ndk_version}}/toolchains/llvm/prebuilt/linux-x86_64/bin",
         prefix=f"{arch}-linux-android{ eabi }21-",
         suffix="",
         clang_args="",
@@ -100,6 +100,8 @@ def build_environment(c):
     if c.platform == "web" and c.kind not in ( "host",  "host-python", "cross" ):
         emsdk_environment(c)
 
+    if c.platform == "android":
+        c.var("ndk_version", "android-ndk-r25b")
 
     cpuccount = os.cpu_count()
 

--- a/tasks/toolchain.py
+++ b/tasks/toolchain.py
@@ -51,13 +51,13 @@ def usrinclude(c: Context):
 @task(kind="cross", platforms="android", always=True)
 def build(c: Context):
 
-    if c.path("{{cross}}/android-ndk-r25b").exists():
+    if c.path("{{cross}}/{{ndk_version}}").exists():
         return
 
     c.clean("{{cross}}")
     c.chdir("{{cross}}")
 
-    c.run("""unzip -q {{ tars }}/android-ndk-r25b-linux.zip""")
+    c.run("""unzip -q {{ tars }}/{{ndk_version}}-linux.zip""")
 
 @task(kind="cross", platforms="mac")
 def build(c: Context):


### PR DESCRIPTION
Split from #82, which is needed by #83.
https://github.com/renpy/renpy-build/blob/6d230ccdebb97d127f550392ccf1b066f34fb743/renpybuild/run.py#L287