### PR TITLE
Add wayland pc files for linux sysroot.

### DIFF
--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -412,7 +412,7 @@ def build_environment(c):
         c.var("cmake_system_processor", "generic")
 
 
-    if c.kind != "host" or c.kind != "host-python" or c.kind != "cross":
+    if c.kind not in ( "host", "host-python", "cross" ):
         c.env("PKG_CONFIG_LIBDIR", "{{ install }}/lib/pkgconfig:{{ PKG_CONFIG_LIBDIR }}")
 
     c.env("PKG_CONFIG", "pkg-config --static")

--- a/source/wayland-pc-files/wayland-client.pc
+++ b/source/wayland-pc-files/wayland-client.pc
@@ -1,0 +1,14 @@
+prefix=/usr
+libdir=${prefix}/lib/x86_64-linux-gnu
+includedir=${prefix}/include
+
+datarootdir=${prefix}/share
+pkgdatadir=${datarootdir}/wayland
+
+Name: Wayland Client
+Description: Wayland client side library
+Version: 1.20.0
+Requires.private: libffi
+Libs: -L${libdir} -lwayland-client
+Libs.private: -lm -pthread
+Cflags: -I${includedir}

--- a/source/wayland-pc-files/wayland-cursor.pc
+++ b/source/wayland-pc-files/wayland-cursor.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+libdir=${prefix}/lib/x86_64-linux-gnu
+includedir=${prefix}/include
+
+Name: Wayland Cursor
+Description: Wayland cursor helper library
+Version: 1.20.0
+Requires.private: wayland-client
+Libs: -L${libdir} -lwayland-cursor
+Cflags: -I${includedir}

--- a/source/wayland-pc-files/wayland-egl.pc
+++ b/source/wayland-pc-files/wayland-egl.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+libdir=${prefix}/lib/x86_64-linux-gnu
+includedir=${prefix}/include
+
+Name: wayland-egl
+Description: Frontend wayland-egl library
+Version: 18.1.0
+Requires: wayland-client
+Libs: -L${libdir} -lwayland-egl
+Cflags: -I${includedir}

--- a/source/wayland-pc-files/wayland-scanner.pc
+++ b/source/wayland-pc-files/wayland-scanner.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+libdir=${prefix}/lib/x86_64-linux-gnu
+includedir=${prefix}/include
+
+datarootdir=${prefix}/share
+pkgdatadir=${datarootdir}/wayland
+bindir=${prefix}/bin
+wayland_scanner=${bindir}/wayland-scanner
+
+Name: Wayland Scanner
+Description: Wayland scanner
+Version: 1.20.0
+Cflags: -I${includedir}

--- a/source/wayland-pc-files/wayland-server.pc
+++ b/source/wayland-pc-files/wayland-server.pc
@@ -1,0 +1,14 @@
+prefix=/usr
+libdir=${prefix}/lib/x86_64-linux-gnu
+includedir=${prefix}/include
+
+datarootdir=${prefix}/share
+pkgdatadir=${datarootdir}/wayland
+
+Name: Wayland Server
+Description: Server side implementation of the Wayland protocol
+Version: 1.20.0
+Requires.private: libffi
+Libs: -L${libdir} -lwayland-server
+Libs.private: -lm -pthread
+Cflags: -I${includedir}

--- a/tasks/sysroot.py
+++ b/tasks/sysroot.py
@@ -161,3 +161,6 @@ def update_wayland_headers(c: Context):
 
     for i in c.path("{{source}}/wayland-headers/").glob("wayland*.h"):
         c.copy(str(i), "{{ sysroot }}/usr/include/" + i.name)
+
+    for i in c.path("{{source}}/wayland-pc-files/").glob("wayland*.pc"):
+        c.copy(str(i), "{{ sysroot }}/usr/lib/{{architecture_name}}/pkgconfig/" + i.name)


### PR DESCRIPTION
This pr fixes the wayland library link during the sdl build. Since the ubuntu 16.04 used by sysroot does not have `libwayland-dev`, manually copy the pc file to sysroot, keeping the prefix `/usr` so that sdl2 can dynamically load the host's wayland library.