### PR TITLE
Include additional dependencies in prepare.sh

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -25,8 +25,14 @@ sudo apt-get install -y debootstrap qemu-user-static
 # Needed by gcc.
 sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev
 
+# Needed by llvm.
+sudo apt-get install -y software-properties-common
+
 # Needed by hostpython.
 sudo apt-get install -y libssl-dev libbz2-dev liblzma-dev
+
+# Needed by brotli.
+sudo apt-get install -y bc
 
 # Needed for mac
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake clang libxml2-dev llvm


### PR DESCRIPTION
This is probably down to the base image used for the 22.04 VM, but making these dependencies explicit shouldn't hurt anything as they'll no-op if already installed.

<details><summary><code>llvm.sh</code> requires <code>add-apt-repository</code> which is part of the <code>software-properties-common</code> package.</summary>

```
--2023-08-07 02:10:42--  https://apt.llvm.org/llvm.sh
Resolving apt.llvm.org (apt.llvm.org)... 199.232.194.49, 199.232.198.49, 2a04:4e42:4c::561, ...
Connecting to apt.llvm.org (apt.llvm.org)|199.232.194.49|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 5558 (5.4K) [application/octet-stream]
Saving to: ‘tmp/llvm.sh’

tmp/llvm.sh 100%[===============================================>]   5.43K  --.-KB/s    in 0.001s

2023-08-07 02:10:44 (4.94 MB/s) - ‘tmp/llvm.sh’ saved [5558/5558]

+ CURRENT_LLVM_STABLE=17
+ BASE_URL=http://apt.llvm.org
+ needed_binaries=(lsb_release wget add-apt-repository gpg)
+ missing_binaries=()
+ for binary in "${needed_binaries[@]}"
+ which lsb_release
+ for binary in "${needed_binaries[@]}"
+ which wget
+ for binary in "${needed_binaries[@]}"
+ which add-apt-repository
+ missing_binaries+=($binary)
+ for binary in "${needed_binaries[@]}"
+ which gpg
+ [[ 1 -gt 0 ]]
+ echo 'You are missing some tools this script requires: add-apt-repository'
You are missing some tools this script requires: add-apt-repository
+ echo '(hint: apt install lsb-release wget software-properties-common gnupg)'
(hint: apt install lsb-release wget software-properties-common gnupg)
+ exit 4
```
</details>

<details><summary><code>build-brotli.linux-x86_64</code> requires <code>bc</code> from eponymous package.</summary>

```
unpack-brotli.linux-x86_64 running in /home/rb/renpy-build/tmp/build/brotli.linux-x86_64 ...

build-brotli.linux-x86_64 running in /home/rb/renpy-build/tmp/build/brotli.linux-x86_64 ...
'bc' is required, but not installed.
build-brotli.linux-x86_64: process failed with 1.
args: ['bash', './bootstrap']
  File "/home/rb/renpy-build/./build.py", line 231, in <module>
    main()
  File "/home/rb/renpy-build/./build.py", line 227, in main
    args.function(args)
  File "/home/rb/renpy-build/./build.py", line 122, in build
    task.run(context)
  File "/home/rb/renpy-build/renpybuild/task.py", line 97, in run
    self.function(context)
  File "/home/rb/renpy-build/tasks/brotli.py", line 18, in build
    c.run("""bash ./bootstrap""")
  File "/home/rb/renpy-build/renpybuild/context.py", line 330, in run
    renpybuild.run.run(command, self, verbose, quiet)
  File "/home/rb/renpy-build/renpybuild/run.py", line 449, in run
    traceback.print_stack()
```