### PR TITLE
Update app-AndroidManifest.xml

### DIFF
--- a/rapt/templates/app-AndroidManifest.xml
+++ b/rapt/templates/app-AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
 
   <application
       android:allowBackup="true"


### PR DESCRIPTION
allow renpy games to be moved to the sd card by enabling the android install location flag. given most vns are in the >200mb size range, people who play many vns and own a compatible phone and large sd card will benefit from this. tested with the question and other projects, loading time not noticeably increased. 
more info: https://developer.android.com/guide/topics/data/install-location

![Screenshot_20230829-211038_Settings](https://github.com/renpy/renpy-build/assets/76508025/b20ef975-c541-4f9d-8f14-14f7208078bc)
![Screenshot_20230829-215547_Settings](https://github.com/renpy/renpy-build/assets/76508025/804a8437-5362-4161-b3c0-50a115ea4b59)
