### PR TITLE
Actually enable mmx.

### DIFF
--- a/tasks/ffmpeg.py
+++ b/tasks/ffmpeg.py
@@ -96,8 +96,10 @@ def build(c: Context):
         --enable-w32threads
 {% endif %}
 
+{% if c.platform == "mac" or c.platform == "ios" %}
         --disable-mmx
         --disable-mmxext
+{% endif %}
 
         --enable-ffmpeg
         --enable-ffplay
@@ -225,10 +227,6 @@ def build_web(c: Context):
         --enable-cross-compile
         --enable-runtime-cpudetect
 
-{% if c.platform == "mac" or c.platform == "ios" %}
-        --disable-mmx
-        --disable-mmxext
-{% endif %}
         --enable-ffmpeg
         --enable-ffplay
         --disable-doc


### PR DESCRIPTION
This is a fix for https://github.com/renpy/renpy-build/commit/560122111aa5ebc3ae5955fcc9411ea70006b8b5 to actually enable mmx for non-Apple platforms, because this commit only enabled mmx on web.