### PR TITLE
Modernise built-in submodule importer

### DIFF
--- a/runtime/site3.py
+++ b/runtime/site3.py
@@ -66,29 +66,28 @@ for fn in RENPY_SEARCH:
 # Submodule importing ##########################################################
 
 # Allow Python to import submodules.
-import imp
+import importlib.machinery
+import importlib.util
 
 
-class BuiltinSubmoduleImporter(object):
+class BuiltinSubmoduleImporter:
 
-    def find_module(self, name, path=None):
+    @staticmethod
+    def find_spec(fullname, path=None, target=None):
         if path is None:
             return None
 
-        if "." not in name:
+        if "." not in fullname:
             return None
 
-        if name in sys.builtin_module_names:
-            return self
+        if fullname not in sys.builtin_module_names:
+            return None
 
-        return None
-
-    def load_module(self, name):
-        f, pathname, desc = imp.find_module(name, None)
-        return imp.load_module(name, f, pathname, desc)
+        i = importlib.machinery.BuiltinImporter
+        return importlib.util.spec_from_loader(fullname, i, origin=i._ORIGIN)
 
 
-sys.meta_path.append(BuiltinSubmoduleImporter())
+sys.meta_path.append(BuiltinSubmoduleImporter)
 
 # Windows Startup ##############################################################
 


### PR DESCRIPTION
The deprecated `imp` module has been removed in Python 3.12.

This change works by implementing the [`MetaPathFinder`](https://docs.python.org/3.12/library/importlib.html#importlib.abc.MetaPathFinder) API, and returning a `ModuleSpec` which tells the other import machinery to use the `BuiltinImporter` provided as part of Python proper to handle loading of these modules.

Tested with Ren'Py 8.1.3.