### PR TITLE
Avoid creating junk *.pem.pyc files

### DIFF
--- a/tasks/pythonlib.py
+++ b/tasks/pythonlib.py
@@ -498,7 +498,7 @@ def python3(c: Context):
 
     for base in search:
 
-        for fn in list(base.glob("**/*cpython-*.pyc")) + list(base.glob("**/*.pem")):
+        for fn in base.glob("**/*cpython-*.pyc"):
             if fn.match("*.opt-?.pyc"):
                 continue
 


### PR DESCRIPTION
The only PEM file we need is the one from Certifi which is [explicitly handled already](https://github.com/renpy/renpy-build/blob/9511d9f30aafc9d09860b00752f18d755a902f87/tasks/pythonlib.py#L553), so don't include PEM files in PYC sync.

The following files were being created and included in the SDK, but will be no longer:
```
renpy/lib/python3.9/certifi/cacert.pem.pyc                                                                            
renpy/lib/python3.9/future/backports/test/nokia.pem.pyc                                                               
renpy/lib/python3.9/future/backports/test/ssl_key.passwd.pem.pyc                                                      
renpy/lib/python3.9/future/backports/test/https_svn_python_org_root.pem.pyc                                           
renpy/lib/python3.9/future/backports/test/nullcert.pem.pyc                                                            
renpy/lib/python3.9/future/backports/test/dh512.pem.pyc                                                               
renpy/lib/python3.9/future/backports/test/keycert2.pem.pyc                                                            
renpy/lib/python3.9/future/backports/test/sha256.pem.pyc                                                              
renpy/lib/python3.9/future/backports/test/nullbytecert.pem.pyc                                                        
renpy/lib/python3.9/future/backports/test/ssl_key.pem.pyc                                                             
renpy/lib/python3.9/future/backports/test/badkey.pem.pyc                                                              
renpy/lib/python3.9/future/backports/test/keycert.passwd.pem.pyc                                                      
renpy/lib/python3.9/future/backports/test/keycert.pem.pyc                                                             
renpy/lib/python3.9/future/backports/test/badcert.pem.pyc                                                             
renpy/lib/python3.9/future/backports/test/ssl_cert.pem.pyc
```