### PR TITLE
Leverage PEP552 to avoid churn in packaged PYCs

### DIFF
--- a/patches/Python-3.9.10/deterministic-pycs.diff
+++ b/patches/Python-3.9.10/deterministic-pycs.diff
@@ -1,0 +1,51 @@
+Avoid baking build-time timestamps into Python bytecode.
+
+From: Mal Graty <mal.graty@googlemail.com>
+
+We only ship pyc files from the stdlib, and to reduce churn during
+updates we don't want to include the timestamp in the bytecode.
+---
+ Makefile.pre.in | 12 ++++++------
+  1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index 42b1ec622a..059e033c3f 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -1551,30 +1551,30 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
+ 	fi
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST)  $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-j0 -d $(LIBDEST) -f \
++		-j0 -d $(LIBDEST) -f --invalidation-mode unchecked-hash \
+ 		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+ 		$(DESTDIR)$(LIBDEST)
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-j0 -d $(LIBDEST) -f \
++		-j0 -d $(LIBDEST) -f --invalidation-mode unchecked-hash \
+ 		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+ 		$(DESTDIR)$(LIBDEST)
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-j0 -d $(LIBDEST) -f \
++		-j0 -d $(LIBDEST) -f --invalidation-mode unchecked-hash \
+ 		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+ 		$(DESTDIR)$(LIBDEST)
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-j0 -d $(LIBDEST)/site-packages -f \
++		-j0 -d $(LIBDEST)/site-packages -f --invalidation-mode unchecked-hash \
+ 		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi -O $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-j0 -d $(LIBDEST)/site-packages -f \
++		-j0 -d $(LIBDEST)/site-packages -f --invalidation-mode unchecked-hash \
+ 		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi -OO $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-j0 -d $(LIBDEST)/site-packages -f \
++		-j0 -d $(LIBDEST)/site-packages -f --invalidation-mode unchecked-hash \
+ 		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -m lib2to3.pgen2.driver $(DESTDIR)$(LIBDEST)/lib2to3/Grammar.txt

--- a/tasks/pyjnius.py
+++ b/tasks/pyjnius.py
@@ -66,8 +66,10 @@ cdef JNIEnv *get_platform_jnienv():
     c.run("""install env.py  __init__.py  reflect.py  signatures.py {{ pytmp }}/pyjnius/jnius""")
     c.run("""install jnius.c {{ pytmp }}/pyjnius/""")
 
-    c.run("{{ hostpython }} -OO -m compileall {{ pytmp }}/pyjnius/jnius")
-    c.run("{{ hostpython }} -m compileall {{ pytmp }}/pyjnius/jnius")
+    if c.python == "2":
+        c.run("{{ hostpython }} -OO -m compileall {{ pytmp }}/pyjnius/jnius")
+    else:
+        c.run("{{ hostpython }} -m compileall {{ pycflags }} {{ pytmp }}/pyjnius/jnius")
 
     with open(c.path("{{ pytmp }}/pyjnius/Setup"), "w") as f:
         f.write(c.expand("""\

--- a/tasks/pyobjus.py
+++ b/tasks/pyobjus.py
@@ -88,5 +88,7 @@ def host_build(c: Context):
     c.run("""install -d {{ pytmp }}/pyobjus/pyobjus""")
     c.run("""install dylib_manager.py  __init__.py  objc_py_types.py  protocols.py {{ pytmp }}/pyobjus/pyobjus""")
 
-    c.run("{{ hostpython }} -OO -m compileall {{ pytmp }}/pyobjus/pyobjus")
-    c.run("{{ hostpython }} -m compileall {{ pytmp }}/pyobjus/pyobjus")
+    if c.python == "2":
+        c.run("{{ hostpython }} -OO -m compileall {{ pytmp }}/pyobjus/pyobjus")
+    else:
+        c.run("{{ hostpython }} -m compileall {{ pycflags }} {{ pytmp }}/pyobjus/pyobjus")

--- a/tasks/python3.py
+++ b/tasks/python3.py
@@ -15,6 +15,7 @@ def annotate(c: Context):
         else:
             c.var("pythonver", "python3.9")
             c.var("pycver", "39")
+            c.var("pycflags", "-q --invalidation-mode unchecked-hash")
 
         c.include("{{ install }}/include/{{ pythonver }}")
 
@@ -49,6 +50,7 @@ def patch_posix(c: Context):
     c.patch("Python-{{ version }}/cross-darwin.diff")
     c.patch("Python-{{ version }}/fix-ssl-dont-use-enum_certificates.diff")
     c.patch("Python-{{ version }}/no-builtin-available.diff")
+    c.patch("Python-{{ version }}/deterministic-pycs.diff")
 
     c.run(""" autoreconf -vfi """)
 
@@ -72,6 +74,7 @@ def patch_windows(c: Context):
     c.patch("Python-{{ version }}/allow-old-mingw.diff")
     c.patch("Python-{{ version }}/single-dllmain.diff")
     c.patch("Python-{{ version }}/fix-overlapped-conflict.diff")
+    c.patch("Python-{{ version }}/deterministic-pycs.diff")
 
     c.run(""" autoreconf -vfi """)
 

--- a/tasks/pythonlib.py
+++ b/tasks/pythonlib.py
@@ -494,7 +494,7 @@ def python3(c: Context):
     dist = c.path("{{ distlib }}/{{ pythonver }}")
 
     c.clean("{{ distlib }}/{{ pythonver }}")
-    c.run("{{ hostpython }} -m compileall -q {{ install }}/lib/{{ pythonver }}/site-packages")
+    c.run("{{ hostpython }} -m compileall {{ pycflags }} {{ install }}/lib/{{ pythonver }}/site-packages")
 
     for base in search:
 
@@ -539,11 +539,11 @@ def python3(c: Context):
             f.write("import site\n")
             f.write("site.renpy_build_official = True\n")
 
-    c.run("{{ hostpython }} -m compileall -q -b {{ distlib }}/{{ pythonver }}/sitecustomize.py")
+    c.run("{{ hostpython }} -m compileall {{ pycflags }} -b {{ distlib }}/{{ pythonver }}/sitecustomize.py")
     c.unlink("{{ distlib }}/{{ pythonver }}/sitecustomize.py")
 
     c.copy("{{ runtime }}/sysconfig.py", "{{ distlib }}/{{ pythonver }}/sysconfig.py")
-    c.run("{{ hostpython }} -m compileall -q -b {{ distlib }}/{{ pythonver }}/sysconfig.py")
+    c.run("{{ hostpython }} -m compileall {{ pycflags }} -b {{ distlib }}/{{ pythonver }}/sysconfig.py")
     c.unlink("{{ distlib }}/{{ pythonver }}/sysconfig.py")
 
     c.run("mkdir -p {{ distlib }}/{{ pythonver }}/lib-dynload")

--- a/tasks/steam.py
+++ b/tasks/steam.py
@@ -53,4 +53,4 @@ def build(c: Context):
     if c.python == "2":
         c.run("{{ hostpython }} -OO -m compileall {{pytmp}}/steam")
     else:
-        c.run("{{ hostpython }} -m compileall {{pytmp}}/steam")
+        c.run("{{ hostpython }} -m compileall {{ pycflags }} {{pytmp}}/steam")


### PR DESCRIPTION
By default `.pyc` files include a compile-time timestamp to aid with invalidation. As we only ship `.pyc` files, those timestamps aren't used. By using the `unchecked-hash` invalidation option during generation we gain stability in `.pyc` files allowing them to be skipped during updates.

The change to the generated bytecode is to include a hash of the source file in the header, in place of the timestamp, so if the source file content doesn't change, the resulting bytecode will be unchanged, allowing the update process to skip over it.

The `checked-hash` option was considered, but as we don't ship `.py` files for the stdlib (and site-packages) there's nothing to check against, and in the unlikely event that a creator did add source files they would win by default due to [PEP 3147](https://peps.python.org/pep-3147/) (source files are preferred over bytecode files in the same directory since the introduction of `__pycache__`).