### PR TITLE
fix: remove `presplash` block

### DIFF
--- a/runtime/web/renpy-pre.js
+++ b/runtime/web/renpy-pre.js
@@ -38,6 +38,9 @@ Module.preRun = Module.preRun || [ ];
     let statusTextDiv = document.getElementById("statusTextDiv");
     let statusProgress = document.getElementById("statusProgress");
 
+    // Presplash block
+    let presplash = document.getElementById('presplash');
+
     // The timeout before the status div hides itself.
     let statusTimeout = null;
 
@@ -257,7 +260,7 @@ Module.preRun = Module.preRun || [ ];
     Module.canvas = canvas;
 
     window.presplashEnd = () => {
-        document.getElementById('presplash').remove();
+        presplash.remove();
         cancelStatusTimeout();
         hideStatus();
     };


### PR DESCRIPTION
When `renpy.utter_restart` is called, `renpy.display.presplash.end` will also be called due to the reinitialization of `renpy.display.core.Interface`, but the block with `presplash` will no longer exist in the DOM tree.