### PR TITLE
Support restricting host tasks

### DIFF
--- a/renpybuild/task.py
+++ b/renpybuild/task.py
@@ -59,19 +59,16 @@ class Task:
             else:
                 return have in wanted
 
-        if not self.kind == "host":
+        if not check(self.platforms, context.platform):
+            return
 
-            if not check(self.platforms, context.platform):
-                return
+        if not check(self.archs, context.arch):
+            return
 
-            if not check(self.archs, context.arch):
-                return
+        if not check(self.pythons, context.python):
+            return
 
-            if not check(self.pythons, context.python):
-                return
-
-        else:
-
+        if self.kind == "host":
             context.platform = "host"
             context.arch = "host"
 

--- a/tasks/freetype.py
+++ b/tasks/freetype.py
@@ -9,7 +9,7 @@ def annotate(c: Context):
     c.include("{{ install }}/include/freetype2")
 
 
-@task(kind="host")
+@task(kind="host", platforms="all")
 def hostunpack(c: Context):
     c.clean()
 
@@ -33,7 +33,7 @@ def unpack(c: Context):
     c.patch("freetype-otvalid.diff")
 
 
-@task(kind="host")
+@task(kind="host", platforms="all")
 def hostbuild(c: Context):
     c.var("version", version)
     c.chdir("freetype-{{version}}")

--- a/tasks/freetypehb.py
+++ b/tasks/freetypehb.py
@@ -9,7 +9,7 @@ def annotate(c: Context):
     c.include("{{ install }}/include/freetype2")
 
 
-@task(kind="host")
+@task(kind="host", platforms="all")
 def hostunpack(c: Context):
     c.clean()
 
@@ -33,7 +33,7 @@ def unpack(c: Context):
     c.patch("freetype-otvalid.diff")
 
 
-@task(kind="host")
+@task(kind="host", platforms="all")
 def hostbuild(c: Context):
     c.var("version", version)
     c.chdir("freetype-{{version}}")

--- a/tasks/hostpython2.py
+++ b/tasks/hostpython2.py
@@ -4,7 +4,7 @@ from renpybuild.task import task
 version = "2.7.18"
 
 
-@task(kind="host", pythons="2")
+@task(kind="host", platforms="all", pythons="2")
 def unpack_hostpython(c: Context):
     c.clean()
 
@@ -14,7 +14,7 @@ def unpack_hostpython(c: Context):
     c.chdir("Python-{{ version }}")
 
 
-@task(kind="host", pythons="2")
+@task(kind="host", platforms="all", pythons="2")
 def build_host(c: Context):
     c.var("version", version)
 

--- a/tasks/hostpython3.py
+++ b/tasks/hostpython3.py
@@ -6,7 +6,7 @@ version = "3.9.10"
 web_version = "3.11.0"
 
 
-@task(kind="host", platforms="all", pythons="3")
+@task(kind="host", pythons="3")
 def unpack_hostpython(c: Context):
     c.clean()
 
@@ -14,7 +14,7 @@ def unpack_hostpython(c: Context):
     c.run("tar xzf {{source}}/Python-{{version}}.tgz")
 
 
-@task(kind="host", platforms="all", pythons="3")
+@task(kind="host", pythons="3")
 def build_host(c: Context):
     c.var("version", version)
 
@@ -31,7 +31,7 @@ def build_host(c: Context):
 
 
 
-@task(kind="host", platforms="all", pythons="3")
+@task(kind="host", platforms="web", pythons="3")
 def unpack_web(c: Context):
     c.clean()
 
@@ -39,7 +39,7 @@ def unpack_web(c: Context):
     c.run("tar xzf {{source}}/Python-{{version}}.tgz")
 
 
-@task(kind="host", platforms="all", pythons="3")
+@task(kind="host", platforms="web", pythons="3")
 def build_web(c: Context):
     c.var("version", web_version)
 

--- a/tasks/hostpython3.py
+++ b/tasks/hostpython3.py
@@ -6,7 +6,7 @@ version = "3.9.10"
 web_version = "3.11.0"
 
 
-@task(kind="host", pythons="3")
+@task(kind="host", platforms="all", pythons="3")
 def unpack_hostpython(c: Context):
     c.clean()
 
@@ -14,7 +14,7 @@ def unpack_hostpython(c: Context):
     c.run("tar xzf {{source}}/Python-{{version}}.tgz")
 
 
-@task(kind="host", pythons="3")
+@task(kind="host", platforms="all", pythons="3")
 def build_host(c: Context):
     c.var("version", version)
 
@@ -31,7 +31,7 @@ def build_host(c: Context):
 
 
 
-@task(kind="host", pythons="3")
+@task(kind="host", platforms="all", pythons="3")
 def unpack_web(c: Context):
     c.clean()
 
@@ -39,7 +39,7 @@ def unpack_web(c: Context):
     c.run("tar xzf {{source}}/Python-{{version}}.tgz")
 
 
-@task(kind="host", pythons="3")
+@task(kind="host", platforms="all", pythons="3")
 def build_web(c: Context):
     c.var("version", web_version)
 

--- a/tasks/nasm.py
+++ b/tasks/nasm.py
@@ -4,7 +4,7 @@ from renpybuild.task import task
 version = "2.14.02"
 
 
-@task(kind="host")
+@task(kind="host", platforms="all")
 def unpack(c: Context):
     c.clean()
 
@@ -12,7 +12,7 @@ def unpack(c: Context):
     c.run("tar xaf {{source}}/nasm-{{version}}.tar.gz")
 
 
-@task(kind="host")
+@task(kind="host", platforms="all")
 def build(c: Context):
     c.var("version", version)
 

--- a/tasks/steam.py
+++ b/tasks/steam.py
@@ -3,7 +3,7 @@ from renpybuild.task import task
 import zipfile
 
 
-@task(kind="host")
+@task(kind="host", platforms="all")
 def unpack_sdk(c: Context):
 
     c.clean("{{ install }}/steam")
@@ -16,7 +16,7 @@ def unpack_sdk(c: Context):
     zf.close()
 
 
-@task(kind="host")
+@task(kind="host", platforms="all")
 def patch_sdk(c: Context):
 
     if not c.path("{{host}}/steam/sdk").exists():


### PR DESCRIPTION
This improves the experience when building only certain versions of python, or platforms. A real world case for this is that it removes the need to build `python2.7` and `python3.11` when building for py3 linux which only requires `python3.9`.

Works by enabling the restriction checks on `kind="host"` tasks, and explicitly adding `platforms="all"` to existing tasks.