### PR TITLE
Disable random hash seed during builds

### DIFF
--- a/build.py
+++ b/build.py
@@ -228,4 +228,11 @@ def main():
 
 
 if __name__ == "__main__":
+    import os
+
+    if os.environ.get('PYTHONHASHSEED') is None:
+        os.environ['PYTHONHASHSEED'] = "0"
+        os.execv(sys.executable, sys.orig_argv)
+        # script will now re-execute with new hash seed
+
     main()


### PR DESCRIPTION
Ensures that the marshal output of frozensets is consistent. With any luck this is the final step to making pyc files deterministic.

This could also have been done as part of the venv activation script, however patching that would have been more involved, and problematic to apply it to existing build environments.