### PR TITLE
Optimize the use of cmake in building

### DIFF
--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -203,10 +203,10 @@ def build_environment(c):
 
         llvm(c)
         c.env("LDFLAGS", "{{ LDFLAGS }} -L{{install}}/lib64")
-        c.env("PKG_CONFIG_PATH", "{{ install }}/lib/pkgconfig")
+        # c.env("PKG_CONFIG_PATH", "{{ install }}/lib/pkgconfig")
 
-        c.var("cmake_system_name", "Linux")
-        c.var("cmake_system_processor", "x86_64")
+        # c.var("cmake_system_name", "Linux")
+        # c.var("cmake_system_processor", "x86_64")
 
     elif (c.platform == "linux") and (c.arch == "x86_64"):
 
@@ -417,14 +417,14 @@ def build_environment(c):
 
     if c.kind not in ( "host", "host-python", "cross" ):
         c.env("PKG_CONFIG_LIBDIR", "{{ install }}/lib/pkgconfig:{{ PKG_CONFIG_LIBDIR }}")
-        c.var("cmake_args", "{{cmake_args}} -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY")
+        c.var("cmake_args", "{{cmake_args}} -DCMAKE_SYSTEM_NAME={{ cmake_system_name }} -DCMAKE_SYSTEM_PROCESSOR={{ cmake_system_processor }} -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY")
 
     c.env("PKG_CONFIG", "pkg-config --static")
 
     c.env("CFLAGS", "{{ CFLAGS }} -DRENPY_BUILD")
     c.env("CXXFLAGS", "{{ CFLAGS }}")
 
-    c.var("cmake", "cmake {{ cmake_args }} -DCMAKE_SYSTEM_NAME={{ cmake_system_name }} -DCMAKE_SYSTEM_PROCESSOR={{ cmake_system_processor }} -DCMAKE_BUILD_TYPE=Release")
+    c.var("cmake", "cmake {{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release")
 
     # Used by zlib.
     if c.kind != "host":

--- a/tools/cmake_build_variables.cmake
+++ b/tools/cmake_build_variables.cmake
@@ -1,0 +1,38 @@
+macro(set_variable_without_ccache VAR ENV_ARG)
+    # Remove "ccache" in environment variables and set
+    # the related cmake variable to it
+    string(REGEX REPLACE "^ccache " "" NO_CCACHE $ENV{${ENV_ARG}})
+    set(${VAR} ${NO_CCACHE})
+endmacro()
+
+macro(set_env_without_ccache VAR)
+    # Remove "ccache" in environment variables, but instead
+    # of setting the cmake variable, let cmake itself set it by
+    # environment variable to ensure that the parameters are
+    # passed correctly
+    string(REGEX REPLACE "^ccache " "" NO_CCACHE $ENV{${VAR}})
+    set(ENV{${VAR}} ${NO_CCACHE})
+endmacro()
+
+set_env_without_ccache(CC)
+set_env_without_ccache(CXX)
+set_env_without_ccache(CPP)
+set_variable_without_ccache(CMAKE_AR AR)
+set_variable_without_ccache(CMAKE_RANLIB RANLIB)
+set_variable_without_ccache(CMAKE_STRIP STRIP)
+
+if(DEFINED ENV{RC})
+    set_variable_without_ccache(CMAKE_RC_COMPILER RC)
+endif()
+
+if(DEFINED ENV{LD})
+    set_env_without_ccache(LD)
+endif()
+
+if(DEFINED ENV{LDSHARED})
+    set_env_without_ccache(LDSHARED)
+endif()
+
+# Set "CMAKE_<LANG>_COMPILER_LAUNCHER" to tell cmake to use ccache
+set(CMAKE_C_COMPILER_LAUNCHER "ccache")
+set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")


### PR DESCRIPTION
In cmake, if the environment variables `CC` and `CXX` start with `ccache`, cmake will set `CMAKE_<LANG>_COMPILER` to ccache instead of clang or clang++, which will cause camke to use the wrong tools in the toolchain, e.g., when cross-compiling x86_64 windows, camke will use the host's `/usr/bin/llvm-ar` instead of `x86_64-w64-mingw32-llvm-ar`.

This cmake file removes ccache from the environment variable so that cmake can correctly recognizes compiler and prefer the tools in the cross-compile toolchain, and sets `CMAKE_<LANG>_COMPILER_LAUNCHER` to tell cmake to use ccache.