### PR TITLE
zsync: add language extensions support

### DIFF
--- a/patches/zsync-enable-extensions.diff
+++ b/patches/zsync-enable-extensions.diff
@@ -1,0 +1,44 @@
+diff --git a/config.h.in b/config.h.in
+index 95ca8dd..d641ea3 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -88,7 +88,7 @@
+ #undef WITH_DMALLOC
+ 
+ /* Enable BSD extensions if present */
+-#undef _BSD_SOURCE
++// #undef _BSD_SOURCE
+ 
+ /* Number of bits in a file offset, on hosts where this is settable. */
+ #undef _FILE_OFFSET_BITS
+@@ -116,3 +116,15 @@
+ 
+ /* Define to `int' if <sys/types.h> or <sys/socket.h> does not define. */
+ #undef socklen_t
++
++/* Enable GNU extensions on systems that have them.  */
++#ifndef _GNU_SOURCE
++#undef _GNU_SOURCE
++#endif
++
++/* Enable general extensions on macOS.  */
++#ifdef __APPLE__
++#ifndef _DARWIN_C_SOURCE
++#undef _DARWIN_C_SOURCE /* for strncasecmp() */
++#endif
++#endif
+diff --git a/configure b/configure
+index 1e95e0e..bc93045 100755
+--- a/configure
++++ b/configure
+@@ -5228,7 +5228,9 @@ case $host_os in
+ $as_echo "#define _XOPEN_SOURCE 600" >>confdefs.h
+ 
+ 
+-$as_echo "#define _BSD_SOURCE 1" >>confdefs.h
++$as_echo "#define _GNU_SOURCE 1" >>confdefs.h
++
++$as_echo "#define _DARWIN_C_SOURCE 1" >>confdefs.h
+ 
+        ;;
+ esac

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -203,7 +203,7 @@ def build_environment(c):
 
         llvm(c)
         c.env("LDFLAGS", "{{ LDFLAGS }} -L{{install}}/lib64")
-        # c.env("PKG_CONFIG_PATH", "{{ install }}/lib/pkgconfig")
+        c.env("PKG_CONFIG_PATH", "{{ install }}/lib/pkgconfig")
 
         # c.var("cmake_system_name", "Linux")
         # c.var("cmake_system_processor", "x86_64")

--- a/tasks/zsync.py
+++ b/tasks/zsync.py
@@ -20,6 +20,7 @@ def build_linux(c: Context):
     c.chdir("zsync-{{ version }}")
 
     c.patch("zsync-no-isastty.diff", p=1)
+    c.patch("zsync-enable-extensions.diff", p=1)
     c.patch("zsync-compress-5.diff", p=0)
 
     c.run("""./configure {{ cross_config }} --prefix="{{ install }}" """)
@@ -36,6 +37,7 @@ def build_mac(c: Context):
     c.chdir("zsync-{{ version }}")
 
     c.patch("zsync-no-isastty.diff", p=1)
+    c.patch("zsync-enable-extensions.diff", p=1)
     c.patch("zsync-compress-5.diff", p=0)
 
     c.run("""./configure {{ cross_config }} --prefix="{{ install }}" """)


### PR DESCRIPTION
```
http.c:128:13: warning: call to undeclared library function 'strcasecmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (strings.h(buf, "Location"))
            ^
http.c:128:13: note: include the header <strings.h> or explicitly provide a declaration for 'strcasecmp'
http.c:916:17: warning: call to undeclared library function 'strncasecmp' with type 'int (const char *, const char *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            && !strncasecmp(p, "multipart/byteranges", 20)) {
                ^
http.c:916:17: note: include the header <strings.h> or explicitly provide a declaration for 'strncasecmp'
2 warnings generated.
```
Technically, this is treated as a warning, but in stricter compiler policies, this would be treated as an error.

By enabling language extensions, header files that declared  `strcasecmp` and other functions will be automatically included.

Also restore `PKG_CONFIG_PATH` in the host build, that is a silly bug by #114 