### PR TITLE
Optimize emscripten build

### DIFF
--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -209,6 +209,7 @@ def build_environment(c):
 
         # c.var("cmake_system_name", "Linux")
         # c.var("cmake_system_processor", "x86_64")
+        c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH={{ install }}")
 
     elif (c.platform == "linux") and (c.arch == "x86_64"):
 

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -205,7 +205,7 @@ def build_environment(c):
 
         llvm(c)
         c.env("LDFLAGS", "{{ LDFLAGS }} -L{{install}}/lib64")
-        # c.env("PKG_CONFIG_PATH", "{{ install }}/lib/pkgconfig")
+        c.env("PKG_CONFIG_PATH", "{{ install }}/lib/pkgconfig")
 
         # c.var("cmake_system_name", "Linux")
         # c.var("cmake_system_processor", "x86_64")

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -115,6 +115,8 @@ def build_environment(c):
         cpuccount -= 4
 
     c.var("make", "nice make -j " + str(cpuccount))
+    c.var("configure", "./configure")
+    c.var("cmake", "cmake")
 
     c.var("sysroot", c.tmp / f"sysroot.{c.platform}-{c.arch}")
     c.var("build_platform", sysconfig.get_config_var("HOST_GNU_TYPE"))
@@ -387,32 +389,43 @@ def build_environment(c):
 
     elif (c.platform == "web") and (c.arch == "wasm") and (c.name != "web"):
 
+        # Use emscripten wrapper to configure and build
+        c.var("make", "emmake {{ make }}")
+        c.var("configure", "emconfigure ./configure")
+        c.var("cmake", "emcmake cmake")
+
         c.env("CFLAGS", "{{ CFLAGS }} -O3 -sUSE_SDL=2 -sUSE_LIBPNG -sUSE_LIBJPEG=1 -sUSE_BZIP2=1 -sUSE_ZLIB=1")
         c.env("LDFLAGS", "{{ LDFLAGS }} -O3 -sUSE_SDL=2 -sUSE_LIBPNG -sUSE_LIBJPEG=1 -sUSE_BZIP2=1 -sUSE_ZLIB=1 -sEMULATE_FUNCTION_POINTER_CASTS=1")
 
         c.var("emscriptenbin", "{{ cross }}/upstream/emscripten")
-        c.var("crossbin", "{{ cross }}/upstream/emscripten")
+        c.var("crossbin", "{{ cross }}/upstream/bin")
 
-        c.env("CC", "ccache {{ emscriptenbin }}/emcc")
-        c.env("CXX", "ccache {{ emscriptenbin }}/em++")
-        c.env("CPP", "ccache {{ emscriptenbin }}/emcc -E")
-        c.env("LD", "ccache {{ emscriptenbin }}/emcc")
-        c.env("LDSHARED", "ccache {{ emscriptenbin }}/emcc")
-        c.env("AR", "ccache {{ emscriptenbin }}/emar")
-        c.env("RANLIB", "ccache {{ emscriptenbin }}/emranlib")
-        c.env("STRIP", "ccache  {{ emscriptenbin }}/emstrip")
-        c.env("NM", "{{ crossbin}}/llvm-nm")
+        c.env("CC", "{{ emscriptenbin }}/emcc")
+        c.env("CXX", "{{ emscriptenbin }}/em++")
+        c.env("CPP", "{{ emscriptenbin }}/emcc -E")
+        c.env("LD", "{{ emscriptenbin }}/emcc")
+        c.env("LDSHARED", "{{ emscriptenbin }}/emcc")
+        c.env("AR", "{{ emscriptenbin }}/emar")
+        c.env("RANLIB", "{{ emscriptenbin }}/emranlib")
+        c.env("STRIP", "{{ emscriptenbin }}/emstrip")
+        c.env("NM", "{{ emscriptenbin }}/emnm")
 
         c.env("EMSCRIPTEN_TOOLS", "{{emscriptenbin}}/tools")
         c.env("EMSCRIPTEN", "{{emscriptenbin}}")
 
         c.env("PKG_CONFIG_LIBDIR", "{{cross}}/upstream/emscripten/cache/sysroot/lib/pkgconfig:{{cross}}/upstream/emscripten/system/lib/pkgconfig")
+        # Add pkg-file search path for emscripten, since emscripten locked PKG_CONFIG_LIBDIR
+        c.env("EM_PKG_CONFIG_PATH", "{{ install }}/lib/pkgconfig")
+
+        # Tell emcc and em++ to use ccache when building
+        c.env("EM_COMPILER_WRAPPER", "ccache")
 
         # Used to find sdl2-config.
         c.env("PATH", "{{cross}}/upstream/emscripten/system/bin/:{{PATH}}")
 
         c.var("cmake_system_name", "Emscripten")
         c.var("cmake_system_processor", "generic")
+        c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH={{ install }}")
 
 
     if c.kind not in ( "host", "host-python", "cross" ):
@@ -424,7 +437,7 @@ def build_environment(c):
     c.env("CFLAGS", "{{ CFLAGS }} -DRENPY_BUILD")
     c.env("CXXFLAGS", "{{ CFLAGS }}")
 
-    c.var("cmake", "cmake {{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release")
+    c.var("cmake", "{{cmake}} {{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release")
 
     # Used by zlib.
     if c.kind != "host":

--- a/tasks/aom.py
+++ b/tasks/aom.py
@@ -30,8 +30,11 @@ def build(c : Context):
         -DENABLE_TOOLS=0
         -DENABLE_TESTS=0
         -DCONFIG_PIC=1
-        {% if platform == "android" or platform == "ios" or platform == "emscripten" %}
+        {% if platform == "android" or platform == "ios" or platform == "web" %}
         -DCONFIG_RUNTIME_CPU_DETECT=0
+        {% endif %}
+        {% if platform == "web" %}
+        -DAOM_TARGET_CPU=generic
         {% endif %}
         {{ tmp }}/source/aom
         """)

--- a/tasks/brotli.py
+++ b/tasks/brotli.py
@@ -17,7 +17,7 @@ def build(c: Context):
 
     c.run("""bash ./bootstrap""")
 
-    c.run("""./configure {{ cross_config }}
+    c.run("""{{configure}} {{ cross_config }}
           --disable-shared
           --prefix="{{ install }}"
           """)

--- a/tasks/ffmpeg.py
+++ b/tasks/ffmpeg.py
@@ -63,7 +63,7 @@ def build(c: Context):
     c.chdir("ffmpeg-{{version}}")
 
     c.run("""
-    ./configure
+    {{configure}}
         --prefix="{{ install }}"
 
         --arch={{ arch }}
@@ -196,7 +196,7 @@ def build_web(c: Context):
     c.chdir("ffmpeg-{{version}}")
 
     c.run("""
-    ./configure
+    {{configure}}
         --prefix="{{ install }}"
 
         --arch=emscripten

--- a/tasks/freetype.py
+++ b/tasks/freetype.py
@@ -38,7 +38,7 @@ def hostbuild(c: Context):
     c.var("version", version)
     c.chdir("freetype-{{version}}")
 
-    c.run("""./configure --prefix="{{ install }}" --with-harfbuzz=no""")
+    c.run("""{{configure}} --prefix="{{ install }}" --with-harfbuzz=no""")
     c.run("""cp {{source}}/ftoption.h builds/unix/""")
     c.run("""cp {{source}}/ftoption.h builds/mac/""")
     c.run("""cp {{source}}/ftoption.h builds/windows/""")
@@ -51,7 +51,7 @@ def build(c: Context):
     c.var("version", version)
     c.chdir("freetype-{{version}}")
 
-    c.run("""./configure {{ cross_config }} --disable-shared --prefix="{{ install }}" --with-harfbuzz=no""")
+    c.run("""{{configure}} {{ cross_config }} --disable-shared --prefix="{{ install }}" --with-harfbuzz=no""")
     c.run("""cp {{source}}/ftoption.h builds/unix/""")
     c.run("""cp {{source}}/ftoption.h builds/mac/""")
     c.run("""cp {{source}}/ftoption.h builds/windows/""")

--- a/tasks/freetypehb.py
+++ b/tasks/freetypehb.py
@@ -38,7 +38,7 @@ def hostbuild(c: Context):
     c.var("version", version)
     c.chdir("freetype-{{version}}")
 
-    c.run("""./configure --prefix="{{ install }}" --with-harfbuzz=yes""")
+    c.run("""{{configure}} --prefix="{{ install }}" --with-harfbuzz=yes""")
     c.run("""cp {{source}}/ftoption.h builds/unix/""")
     c.run("""cp {{source}}/ftoption.h builds/mac/""")
     c.run("""cp {{source}}/ftoption.h builds/windows/""")
@@ -51,7 +51,7 @@ def build(c: Context):
     c.var("version", version)
     c.chdir("freetype-{{version}}")
 
-    c.run("""./configure {{ cross_config }} --disable-shared --prefix="{{ install }}" --with-harfbuzz=yes""")
+    c.run("""{{configure}} {{ cross_config }} --disable-shared --prefix="{{ install }}" --with-harfbuzz=yes""")
     c.run("""cp {{source}}/ftoption.h builds/unix/""")
     c.run("""cp {{source}}/ftoption.h builds/mac/""")
     c.run("""cp {{source}}/ftoption.h builds/windows/""")

--- a/tasks/fribidi.py
+++ b/tasks/fribidi.py
@@ -18,6 +18,6 @@ def build(c: Context):
     c.chdir("fribidi-{{version}}")
 
     c.run("""cp /usr/share/misc/config.sub config.sub""")
-    c.run("""./configure {{ cross_config }} --disable-shared --prefix="{{ install }}" """)
+    c.run("""{{configure}} {{ cross_config }} --disable-shared --prefix="{{ install }}" """)
     c.run("""{{ make }}""")
     c.run("""make install """)

--- a/tasks/harfbuzz.py
+++ b/tasks/harfbuzz.py
@@ -25,7 +25,7 @@ def build(c: Context):
 
     c.run("""cp /usr/share/misc/config.sub .""")
 
-    c.run("""./configure {{ cross_config }}
+    c.run("""{{configure}} {{ cross_config }}
           --disable-shared
           --prefix="{{ install }}"
           --with-libstdc++=no

--- a/tasks/hostpython2.py
+++ b/tasks/hostpython2.py
@@ -28,7 +28,7 @@ def build_host(c: Context):
 
     c.env("CFLAGS", "{{ CFLAGS }} -DXML_POOR_ENTROPY=1 -DUSE_PYEXPAT_CAPI -DHAVE_EXPAT_CONFIG_H ")
 
-    c.run("""./configure --prefix="{{ host }}" --enable-ipv6""")
+    c.run("""{{configure}} --prefix="{{ host }}" --enable-ipv6""")
 
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
 

--- a/tasks/hostpython3.py
+++ b/tasks/hostpython3.py
@@ -20,7 +20,7 @@ def build_host(c: Context):
 
     c.chdir("Python-{{ version }}")
 
-    c.run("""./configure --prefix="{{ host }}" """)
+    c.run("""{{configure}} --prefix="{{ host }}" """)
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
 
     c.run("""{{ make }} install""")
@@ -47,5 +47,5 @@ def build_web(c: Context):
     c.generate("{{ source }}/Python-{{ version }}-Setup.stdlib", "Modules/Setup.stdlib")
     c.generate("{{ source }}/Python-{{ version }}-Setup.stdlib", "Modules/Setup")
 
-    c.run("""./configure --prefix="{{ host }}/web" """)
+    c.run("""{{configure}} --prefix="{{ host }}/web" """)
     c.run("""{{ make }} install""")

--- a/tasks/libffi.py
+++ b/tasks/libffi.py
@@ -17,6 +17,6 @@ def build(c: Context):
     c.var("version", version)
     c.chdir("libffi-{{version}}")
 
-    c.run("""./configure {{ ffi_cross_config }} --disable-shared --enable-portable-binary --prefix="{{ install }}" """)
+    c.run("""{{configure}} {{ ffi_cross_config }} --disable-shared --enable-portable-binary --prefix="{{ install }}" """)
     c.run("""{{ make }}""")
     c.run("""make install """)

--- a/tasks/libjpeg_turbo.py
+++ b/tasks/libjpeg_turbo.py
@@ -19,11 +19,11 @@ def build(c: Context):
     c.chdir("libjpeg-turbo-{{version}}")
 
     if c.platform == "linux" and c.arch == "i686":
-        c.run("""./configure {{ cross_config }} --disable-shared --prefix="{{ install }}" --without-simd""")
+        c.run("""{{configure}} {{ cross_config }} --disable-shared --prefix="{{ install }}" --without-simd""")
     elif c.platform == "ios" and "sim-x86_64" in c.arch:
-        c.run("""./configure {{ cross_config }} --disable-shared --prefix="{{ install }}" --without-simd""")
+        c.run("""{{configure}} {{ cross_config }} --disable-shared --prefix="{{ install }}" --without-simd""")
     else:
-        c.run("""./configure {{ cross_config }} --disable-shared --prefix="{{ install }}" """)
+        c.run("""{{configure}} {{ cross_config }} --disable-shared --prefix="{{ install }}" """)
 
     c.run("""{{ make }}""")
     c.run("""make install """)

--- a/tasks/libpng.py
+++ b/tasks/libpng.py
@@ -19,6 +19,6 @@ def build(c: Context) :
 
     c.env("CPPFLAGS", "{{ CPPFLAGS }} -DPNG_NO_CONSOLE_IO")
 
-    c.run("""./configure {{ cross_config }} --disable-shared --prefix="{{ install }}" """)
+    c.run("""{{configure}} {{ cross_config }} --disable-shared --prefix="{{ install }}" """)
     c.run("""{{ make }}""")
     c.run("""make install """)

--- a/tasks/libwebp.py
+++ b/tasks/libwebp.py
@@ -18,7 +18,7 @@ def build(c: Context):
     c.chdir("libwebp-{{version}}")
 
     c.run("""
-    ./configure {{ cross_config }}
+    {{configure}} {{ cross_config }}
     --disable-shared
     --prefix="{{ install }}"
 

--- a/tasks/nasm.py
+++ b/tasks/nasm.py
@@ -17,6 +17,6 @@ def build(c: Context):
     c.var("version", version)
 
     c.chdir("nasm-{{version}}")
-    c.run("""./configure --prefix="{{install}}" """)
+    c.run("""{{configure}} --prefix="{{install}}" """)
     c.run("""{{ make }}""")
     c.run("""make install""")

--- a/tasks/openssl.py
+++ b/tasks/openssl.py
@@ -27,6 +27,8 @@ def build(c: Context):
         c.run("""./Configure mingw no-shared no-asm no-engine threads --prefix="{{ install }}" """)
     elif c.platform == "android":
         c.run("""./Configure cc no-shared no-asm no-engine threads --prefix="{{ install }}" """)
+    elif c.platform == "web":
+        c.run("""emconfigure ./Configure cc no-shared no-asm no-engine threads -lpthread --prefix="{{ install }}" """)
     else:
         c.run("""./Configure cc no-shared no-asm no-engine threads -lpthread --prefix="{{ install }}" """)
 

--- a/tasks/python2.py
+++ b/tasks/python2.py
@@ -83,7 +83,7 @@ def build_posix(c: Context):
 
     c.env("CFLAGS", "{{ CFLAGS }} -DXML_POOR_ENTROPY=1 -DUSE_PYEXPAT_CAPI -DHAVE_EXPAT_CONFIG_H ")
 
-    c.run("""./configure {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --enable-ipv6""")
+    c.run("""{{configure}} {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --enable-ipv6""")
 
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
 
@@ -111,7 +111,7 @@ def build_ios(c: Context):
 
     c.env("CFLAGS", "{{ CFLAGS }} -DXML_POOR_ENTROPY=1 -DUSE_PYEXPAT_CAPI -DHAVE_EXPAT_CONFIG_H ")
 
-    c.run("""./configure {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --disable-toolbox-glue --enable-ipv6""")
+    c.run("""{{configure}} {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --disable-toolbox-glue --enable-ipv6""")
 
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
 
@@ -137,7 +137,7 @@ def build_android(c: Context):
 
     c.env("CFLAGS", "{{ CFLAGS }} -DXML_POOR_ENTROPY=1 -DUSE_PYEXPAT_CAPI -DHAVE_EXPAT_CONFIG_H ")
 
-    c.run("""./configure {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --enable-ipv6""")
+    c.run("""{{configure}} {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --enable-ipv6""")
 
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
 
@@ -168,7 +168,7 @@ def build_windows(c: Context):
 
     c.env("CONFIG_SITE", "config.site")
 
-    c.run("""./configure {{ cross_config }} --enable-shared --prefix="{{ install }}" --with-threads --with-system-ffi""")
+    c.run("""{{configure}} {{ cross_config }} --enable-shared --prefix="{{ install }}" --with-threads --with-system-ffi""")
 
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
 

--- a/tasks/python3.py
+++ b/tasks/python3.py
@@ -118,7 +118,7 @@ def build_posix(c: Context):
 
     common(c)
 
-    c.run("""./configure {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --enable-ipv6""")
+    c.run("""{{configure}} {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --enable-ipv6""")
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
     c.run("""{{ make }}""")
     c.run("""{{ make }} install""")
@@ -146,7 +146,7 @@ def build_ios(c: Context):
         f.write("ac_cv_have_long_long_format=yes\n")
         f.write("ac_cv_func_clock_settime=no")
 
-    c.run("""./configure {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --disable-toolbox-glue --enable-ipv6""")
+    c.run("""{{configure}} {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --disable-toolbox-glue --enable-ipv6""")
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
     c.run("""{{ make }} """)
     c.run("""{{ make }} install""")
@@ -161,7 +161,7 @@ def build_android(c: Context):
         f.write("ac_cv_little_endian_double=yes\n")
         f.write("ac_cv_header_langinfo_h=no\n")
 
-    c.run("""./configure {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --enable-ipv6""")
+    c.run("""{{configure}} {{ cross_config }} --prefix="{{ install }}" --with-system-ffi --enable-ipv6""")
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
     c.run("""{{ make }}""")
     c.run("""{{ make }} install""")
@@ -184,7 +184,7 @@ def build_windows(c: Context):
 
     c.env("CFLAGS", "{{ CFLAGS }} -Wno-implicit-function-declaration")
 
-    c.run("""./configure {{ cross_config }} --enable-shared --prefix="{{ install }}" --with-system-ffi""")
+    c.run("""{{configure}} {{ cross_config }} --enable-shared --prefix="{{ install }}" --with-system-ffi""")
 
     c.generate("{{ source }}/Python-{{ version }}-Setup.local", "Modules/Setup.local")
 
@@ -206,7 +206,7 @@ def build_web(c: Context):
     c.env("CONFIG_SITE", "Tools/wasm/config.site-wasm32-emscripten")
 
     c.run("""
-        ./configure {{ cross_config }}
+        {{configure}} {{ cross_config }}
         --prefix="{{ install }}"
         --with-emscripten-target=browser
         --with-build-python={{host}}/web/bin/python3

--- a/tasks/sdl2.py
+++ b/tasks/sdl2.py
@@ -40,7 +40,7 @@ def build(c: Context):
     if not c.args.sdl:
 
         c.run("""
-        ./configure {{ sdl_cross_config }}
+        {{configure}} {{ sdl_cross_config }}
         --disable-shared
         --prefix="{{ install }}"
 

--- a/tasks/sdl2_image.py
+++ b/tasks/sdl2_image.py
@@ -34,7 +34,7 @@ def build(c: Context):
         c.env("SDL_CFLAGS", "-sUSE_SDL=2")
         c.env("SDL_LIBS", "-sUSE_SDL=2")
 
-    c.run("""./configure {{ cross_config }} --prefix="{{ install }}"
+    c.run("""{{configure}} {{ cross_config }} --prefix="{{ install }}"
     --with-gnu-ld
     --disable-shared
 

--- a/tasks/xz.py
+++ b/tasks/xz.py
@@ -17,7 +17,7 @@ def build(c: Context) :
     c.var("version", version)
     c.chdir("xz-{{version}}")
 
-    c.run("""./configure {{ cross_config }} --enable-static --disable-shared --disable-xz --disable-xzdec --disable-lzmainfo --disable-scripts  --prefix="{{ install }}" """)
+    c.run("""{{configure}} {{ cross_config }} --enable-static --disable-shared --disable-xz --disable-xzdec --disable-lzmainfo --disable-scripts  --prefix="{{ install }}" """)
 
     c.run("""rm -f src/common/common_w32res.rc""")
     c.run("""touch src/common/common_w32res.rc""")

--- a/tasks/zlib.py
+++ b/tasks/zlib.py
@@ -16,7 +16,7 @@ def unpack(c: Context):
 def build(c: Context):
     c.var("version", version)
     c.chdir("zlib-{{version}}")
-    c.run("./configure {{ configure_cross }} --static --prefix={{install}}")
+    c.run("{{configure}} {{ configure_cross }} --static --prefix={{install}}")
     c.run("{{ make }}")
     c.run("make install")
 

--- a/tasks/zsync.py
+++ b/tasks/zsync.py
@@ -22,7 +22,7 @@ def build_linux(c: Context):
     c.patch("zsync-no-isastty.diff", p=1)
     c.patch("zsync-compress-5.diff", p=0)
 
-    c.run("""./configure {{ cross_config }} --prefix="{{ install }}" """)
+    c.run("""{{configure}} {{ cross_config }} --prefix="{{ install }}" """)
     c.run("""{{ make }}""")
 
     c.run("install -d {{ dlpa }}")
@@ -38,7 +38,7 @@ def build_mac(c: Context):
     c.patch("zsync-no-isastty.diff", p=1)
     c.patch("zsync-compress-5.diff", p=0)
 
-    c.run("""./configure {{ cross_config }} --prefix="{{ install }}" """)
+    c.run("""{{configure}} {{ cross_config }} --prefix="{{ install }}" """)
     c.run("""{{ make }}""")
 
     c.run("""install -d {{ install }}/mac{{python}}""")


### PR DESCRIPTION
Use emscripten's wrapper build, this allows emscripten to automatically set environment variables and build parameters.

Tested with python 3 and python 2 builds.