### PR TITLE
Make browser request manifest with credentials

### DIFF
--- a/runtime/web/shell.html
+++ b/runtime/web/shell.html
@@ -6,7 +6,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <title>Ren'Py Web Game</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="manifest" href="manifest.json" />
+  <link rel="manifest" href="manifest.json" crossorigin="use-credentials" />
   <link rel="icon" href="icons/icon-72x72.png" sizes="72x72" type="image/png" />
   <link rel="icon" href="icons/icon-96x96.png" sizes="96x96" type="image/png" />
   <link rel="icon" href="icons/icon-128x128.png" sizes="128x128" type="image/png" />


### PR DESCRIPTION
Browsers don't send credentials (Authorization header) when downloading the "manifest.json" file if the "crossorigin" attribute is not set to "use-credentials". This is a problem for sites that use HTTP authentication, because the manifest cannot be downloaded, and Chrome keeps requesting it again and again.

The manifest file is stored on the same site as the "index.html" file, so the origin is the same, yet the crossorigin attribute is needed:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_web_manifest_with_credentials