### PR TITLE
Improve CMake build system integration

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -40,6 +40,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake clang libxml2-dev l
 # Needed for web
 sudo apt-get install -y quilt
 
+# Needed for meson and cmake
+sudo apt-get install -y ninja-build
+
 # Install the standard set of packages needed to build Ren'Py.
 sudo apt-get install -y \
     libavcodec-dev libavformat-dev \

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -49,10 +49,7 @@ def llvm(c, bin="", prefix="", suffix="-15", clang_args="", use_ld=True):
     ld = c.expand("{{llvm_bin}}lld{{llvm_suffix}}")
 
     if use_ld:
-        if c.platform == "linux":
-            clang_args = "-fuse-ld=" + ld + " -Wno-unused-command-line-argument " + clang_args
-        else:
-            clang_args = "-fuse-ld=lld -Wno-unused-command-line-argument " + clang_args
+        clang_args = "-fuse-ld=lld -Wno-unused-command-line-argument " + clang_args
 
     if c.platform == "ios":
         c.var("cxx_clang_args", "-stdlib=libc++ -I{{cross}}/sdk/usr/include/c++")

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -435,7 +435,7 @@ def build_environment(c):
     c.env("CFLAGS", "{{ CFLAGS }} -DRENPY_BUILD")
     c.env("CXXFLAGS", "{{ CFLAGS }}")
 
-    c.var("cmake", "{{cmake}} {{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release")
+    c.var("cmake_args", "{{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release")
 
     # Used by zlib.
     if c.kind != "host":

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -113,7 +113,7 @@ def build_environment(c):
 
     c.var("make", "nice make -j " + str(cpuccount))
     c.var("configure", "./configure")
-    c.var("cmake", "cmake")
+    c.var("cmake_configure", "cmake")
 
     c.var("sysroot", c.tmp / f"sysroot.{c.platform}-{c.arch}")
     c.var("build_platform", sysconfig.get_config_var("HOST_GNU_TYPE"))
@@ -390,7 +390,7 @@ def build_environment(c):
         # Use emscripten wrapper to configure and build
         c.var("make", "emmake {{ make }}")
         c.var("configure", "emconfigure ./configure")
-        c.var("cmake", "emcmake cmake")
+        c.var("cmake_configure", "emcmake cmake")
 
         c.env("CFLAGS", "{{ CFLAGS }} -O3 -sUSE_SDL=2 -sUSE_LIBPNG -sUSE_LIBJPEG=1 -sUSE_BZIP2=1 -sUSE_ZLIB=1")
         c.env("LDFLAGS", "{{ LDFLAGS }} -O3 -sUSE_SDL=2 -sUSE_LIBPNG -sUSE_LIBJPEG=1 -sUSE_BZIP2=1 -sUSE_ZLIB=1 -sEMULATE_FUNCTION_POINTER_CASTS=1")

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -435,7 +435,7 @@ def build_environment(c):
     c.env("CFLAGS", "{{ CFLAGS }} -DRENPY_BUILD")
     c.env("CXXFLAGS", "{{ CFLAGS }}")
 
-    c.var("cmake_args", "{{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release")
+    c.var("cmake_args", "{{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PARALLEL_LEVEL=" + str(cpuccount))
 
     # Used by zlib.
     if c.kind != "host":

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -65,11 +65,11 @@ def llvm(c, bin="", prefix="", suffix="-15", clang_args="", use_ld=True):
     c.env("CPP", "ccache {{llvm_bin}}{{llvm_prefix}}clang{{llvm_suffix}} {{ clang_args }} -E")
 
     # c.env("LD", "ccache " + ld)
-    c.env("AR", "ccache {{llvm_bin}}llvm-ar{{llvm_suffix}}")
-    c.env("RANLIB", "ccache {{llvm_bin}}llvm-ranlib{{llvm_suffix}}")
-    c.env("STRIP", "ccache {{llvm_bin}}llvm-strip{{llvm_suffix}}")
-    c.env("NM", "ccache {{llvm_bin}}llvm-nm{{llvm_suffix}}")
-    c.env("READELF", "ccache {{llvm_bin}}llvm-readelf{{llvm_suffix}}")
+    c.env("AR", "{{llvm_bin}}llvm-ar{{llvm_suffix}}")
+    c.env("RANLIB", "{{llvm_bin}}llvm-ranlib{{llvm_suffix}}")
+    c.env("STRIP", "{{llvm_bin}}llvm-strip{{llvm_suffix}}")
+    c.env("NM", "{{llvm_bin}}llvm-nm{{llvm_suffix}}")
+    c.env("READELF", "{{llvm_bin}}llvm-readelf{{llvm_suffix}}")
 
     c.env("WINDRES", "{{llvm_bin}}{{llvm_prefix}}windres{{llvm_suffix}}")
 

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -435,7 +435,7 @@ def build_environment(c):
     c.env("CFLAGS", "{{ CFLAGS }} -DRENPY_BUILD")
     c.env("CXXFLAGS", "{{ CFLAGS }}")
 
-    c.var("cmake_args", "{{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PARALLEL_LEVEL=" + str(cpuccount))
+    c.var("cmake_args", "-G Ninja {{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PARALLEL_LEVEL=" + str(cpuccount))
 
     # Used by zlib.
     if c.kind != "host":

--- a/tasks/aom.py
+++ b/tasks/aom.py
@@ -23,7 +23,7 @@ def build(c : Context):
     c.clean()
 
     c.run("""
-        {{ cmake }} {{ cmake_args }}
+        {{ cmake_configure }} {{ cmake_args }}
         -DCMAKE_INSTALL_PREFIX={{install}}
         -DCONFIG_AV1_ENCODER=0
         -DENABLE_EXAMPLES=0
@@ -40,8 +40,8 @@ def build(c : Context):
         """)
 
     try:
-        c.run("{{ cmake }} --build .")
+        c.run("cmake --build .")
     except:
-        c.run("{{ cmake }} --build . -j 1 -v")
+        c.run("cmake --build . -j 1 -v")
 
-    c.run("{{ cmake }} --install .")
+    c.run("cmake --install .")

--- a/tasks/aom.py
+++ b/tasks/aom.py
@@ -23,7 +23,7 @@ def build(c : Context):
     c.clean()
 
     c.run("""
-        {{ cmake }}
+        {{ cmake }} {{ cmake_args }}
         -DCMAKE_INSTALL_PREFIX={{install}}
         -DCONFIG_AV1_ENCODER=0
         -DENABLE_EXAMPLES=0
@@ -40,8 +40,8 @@ def build(c : Context):
         """)
 
     try:
-        c.run("{{ make }}")
+        c.run("{{ cmake }} --build .")
     except:
-        c.run("make VERBOSE=1")
+        c.run("{{ cmake }} --build . -j 1 -v")
 
-    c.run("make install")
+    c.run("{{ cmake }} --install .")

--- a/tasks/libavif.py
+++ b/tasks/libavif.py
@@ -13,7 +13,7 @@ def build(c : Context):
     c.clean()
 
     c.run("""
-        {{ cmake }} {{ cmake_args }}
+        {{ cmake_configure }} {{ cmake_args }}
         -DCMAKE_INSTALL_PREFIX={{install}}
         -DAVIF_CODEC_AOM=1
         -DAVIF_CODEC_AOM_ENCODE=0
@@ -22,8 +22,8 @@ def build(c : Context):
         """)
 
     try:
-        c.run("{{ cmake }} --build .")
+        c.run("cmake --build .")
     except:
-        c.run("{{ cmake }} --build . -j 1 -v")
+        c.run("cmake --build . -j 1 -v")
 
-    c.run("{{ cmake }} --install .")
+    c.run("cmake --install .")

--- a/tasks/libavif.py
+++ b/tasks/libavif.py
@@ -13,7 +13,7 @@ def build(c : Context):
     c.clean()
 
     c.run("""
-        {{ cmake }}
+        {{ cmake }} {{ cmake_args }}
         -DCMAKE_INSTALL_PREFIX={{install}}
         -DAVIF_CODEC_AOM=1
         -DAVIF_CODEC_AOM_ENCODE=0
@@ -22,8 +22,8 @@ def build(c : Context):
         """)
 
     try:
-        c.run("{{ make }}")
+        c.run("{{ cmake }} --build .")
     except:
-        c.run("make VERBOSE=1")
+        c.run("{{ cmake }} --build . -j 1 -v")
 
-    c.run("make install")
+    c.run("{{ cmake }} --install .")

--- a/tasks/libyuv.py
+++ b/tasks/libyuv.py
@@ -29,7 +29,7 @@ def build(c : Context):
     c.clean()
 
     c.run("""
-        {{ cmake }}
+        {{ cmake }} {{ cmake_args }}
         -DCMAKE_INSTALL_PREFIX={{install}}
         -DBUILD_SHARED_LIBS=0
         {% if platform == "web" %}
@@ -39,8 +39,8 @@ def build(c : Context):
         """)
 
     try:
-        c.run("{{ make }}")
+        c.run("{{ cmake }} --build .")
     except:
-        c.run("make VERBOSE=1")
+        c.run("{{ cmake }} --build . -j 1 -v")
 
-    c.run("make install")
+    c.run("{{ cmake }} --install .")

--- a/tasks/libyuv.py
+++ b/tasks/libyuv.py
@@ -29,7 +29,7 @@ def build(c : Context):
     c.clean()
 
     c.run("""
-        {{ cmake }} {{ cmake_args }}
+        {{ cmake_configure }} {{ cmake_args }}
         -DCMAKE_INSTALL_PREFIX={{install}}
         -DBUILD_SHARED_LIBS=0
         {% if platform == "web" %}
@@ -39,8 +39,8 @@ def build(c : Context):
         """)
 
     try:
-        c.run("{{ cmake }} --build .")
+        c.run("cmake --build .")
     except:
-        c.run("{{ cmake }} --build . -j 1 -v")
+        c.run("cmake --build . -j 1 -v")
 
-    c.run("{{ cmake }} --install .")
+    c.run("cmake --install .")

--- a/tools/cmake_build_variables.cmake
+++ b/tools/cmake_build_variables.cmake
@@ -28,18 +28,6 @@ set_variable_without_ccache(CMAKE_AR AR)
 set_variable_without_ccache(CMAKE_RANLIB RANLIB)
 set_variable_without_ccache(CMAKE_STRIP STRIP)
 
-if(DEFINED ENV{RC})
-    set_variable_without_ccache(CMAKE_RC_COMPILER RC)
-endif()
-
-if(DEFINED ENV{LD})
-    set_env_without_ccache(LD)
-endif()
-
-if(DEFINED ENV{LDSHARED})
-    set_env_without_ccache(LDSHARED)
-endif()
-
 # Set "CMAKE_<LANG>_COMPILER_LAUNCHER" to tell cmake to use ccache
 set(CMAKE_C_COMPILER_LAUNCHER "ccache")
 set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")

--- a/tools/cmake_build_variables.cmake
+++ b/tools/cmake_build_variables.cmake
@@ -14,6 +14,13 @@ macro(set_env_without_ccache VAR)
     set(ENV{${VAR}} ${NO_CCACHE})
 endmacro()
 
+macro(set_env_without_string VAR REPLACE_STRING)
+    # Remove "REPLACE_STRING" for environment "VAR" and set
+    # the "REPLACED" variable to environment
+    string(REPLACE ${REPLACE_STRING} "" REPLACED $ENV{${VAR}})
+    set(ENV{${VAR}} ${REPLACED})
+endmacro()
+
 set_env_without_ccache(CC)
 set_env_without_ccache(CXX)
 set_env_without_ccache(CPP)
@@ -36,3 +43,34 @@ endif()
 # Set "CMAKE_<LANG>_COMPILER_LAUNCHER" to tell cmake to use ccache
 set(CMAKE_C_COMPILER_LAUNCHER "ccache")
 set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")
+set(CMAKE_OBJC_COMPILER_LAUNCHER "ccache")
+set(CMAKE_OBJCXX_COMPILER_LAUNCHER "ccache")
+
+# Remove "-std=*" from environment
+set_env_without_string(CC " -std=gnu17")
+set_env_without_string(CXX " -std=gnu++17")
+
+# Set "CMAKE_<LANG>_STANDARD" to add flag -std=* for compiler
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_OBJC_STANDARD 17)
+set(CMAKE_OBJCXX_STANDARD 17)
+
+# Set "CMAKE_<LANG>_EXTENSIONS" to use std flag such as -std=gnu17 instead of -std=c17
+set(CMAKE_C_EXTENSIONS ON)
+set(CMAKE_CXX_EXTENSIONS ON)
+set(CMAKE_OBJC_EXTENSIONS ON)
+set(CMAKE_OBJCXX_EXTENSIONS ON)
+
+# Cmake has it own way to set linker since version 3.29, but currently Ubuntu's camke is outdated
+if(CMAKE_VERSION VERSION_GREATER "3.29")
+    set_env_without_string(CC "-fuse-ld=lld -Wno-unused-command-line-argument ")
+    set_env_without_string(CXX "-fuse-ld=lld -Wno-unused-command-line-argument ")
+    set_env_without_string(CPP "-fuse-ld=lld -Wno-unused-command-line-argument ")
+
+    set(CMAKE_LINKER_TYPE LLD)
+    set(CMAKE_C_USING_LINKER_LLD "-fuse-ld=lld")
+    set(CMAKE_CXX_USING_LINKER_LLD "-fuse-ld=lld")
+    set(CMAKE_OBJC_USING_LINKER_LLD "-fuse-ld=lld")
+    set(CMAKE_OBJCXX_USING_LINKER_LLD "-fuse-ld=lld")
+endif()

--- a/tools/cmake_build_variables.cmake
+++ b/tools/cmake_build_variables.cmake
@@ -52,7 +52,7 @@ set(CMAKE_OBJCXX_EXTENSIONS ON)
 
 # Cmake added its own way to set up linker since version 3.29, see
 # https://cmake.org/cmake/help/latest/variable/CMAKE_LINKER_TYPE.html and
-# https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_USING_LINKER_TYPE.html, 
+# https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_USING_LINKER_TYPE.html,
 # but Ubuntu's current version of camke is too low
 if(CMAKE_VERSION VERSION_GREATER "3.29")
     set_env_without_string(CC "-fuse-ld=lld -Wno-unused-command-line-argument ")

--- a/tools/cmake_build_variables.cmake
+++ b/tools/cmake_build_variables.cmake
@@ -50,13 +50,19 @@ set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_OBJC_EXTENSIONS ON)
 set(CMAKE_OBJCXX_EXTENSIONS ON)
 
-# Cmake has it own way to set linker since version 3.29, but currently Ubuntu's camke is outdated
+# Cmake added its own way to set up linker since version 3.29, see
+# https://cmake.org/cmake/help/latest/variable/CMAKE_LINKER_TYPE.html and
+# https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_USING_LINKER_TYPE.html, 
+# but Ubuntu's current version of camke is too low
 if(CMAKE_VERSION VERSION_GREATER "3.29")
     set_env_without_string(CC "-fuse-ld=lld -Wno-unused-command-line-argument ")
     set_env_without_string(CXX "-fuse-ld=lld -Wno-unused-command-line-argument ")
     set_env_without_string(CPP "-fuse-ld=lld -Wno-unused-command-line-argument ")
 
     set(CMAKE_LINKER_TYPE LLD)
+
+    # Specify CMAKE_<LANG>_USING_LINKER_<TYPE> manually because
+    # cmake's default preset does not set them for all platforms.
     set(CMAKE_C_USING_LINKER_LLD "-fuse-ld=lld")
     set(CMAKE_CXX_USING_LINKER_LLD "-fuse-ld=lld")
     set(CMAKE_OBJC_USING_LINKER_LLD "-fuse-ld=lld")


### PR DESCRIPTION
This PR enhances the cmake build system integration, specifically, it does the following things:

- Set `-fuse-ld=lld` directly, this is llvm's recommend method to use lld in https://lld.llvm.org/#using-lld
- Remove `ccache` from the build utils, since ccache is only effective for compiler
- Split variable `cmake` into `cmake_configure` and `cmake_args` for clarity
- Use `ninja` as default generator for cmake to speed up building process
- Add `CMAKE_BUILD_PARALLEL_LEVEL` to control the maximum number of build processes
- Call cmake to compile and install, which allows set generator without changing compile and install commands, and making `CMAKE_BUILD_PARALLEL_LEVEL` take effect automatically
- Prefer to use cmake's own way of setting C/C++ standard and linker type if available, this prevents cmake projects from setting the default value for `CMAKE_<LANG>_STANDARD` and overwriting renpy's C/C++ std version