### PR TITLE
Add meson build system support

### DIFF
--- a/patches/meson-fix-emscripten-std.patch
+++ b/patches/meson-fix-emscripten-std.patch
@@ -1,0 +1,43 @@
+From 77db04ffa6c37496f5a800f2f5cd5a0c19e47d8b Mon Sep 17 00:00:00 2001
+From: Ralf Gommers <ralf.gommers@gmail.com>
+Date: Thu, 16 May 2024 20:46:45 +0200
+Subject: [PATCH] Fix handling of C standard support for Emscripten.
+
+Emscripten version numbers are unrelated to Clang version numbers,
+so it is necessary to change the version checks for `c_std=c17` & co.
+Without that, no project that defaults to C17 or newer will build with
+Emscripten.
+
+See https://github.com/pyodide/pyodide/discussions/4762 for more
+context. Also note that this bug caused defaulting to C17 in
+scikit-learn to be reverted (scikit-learn#29015), and it may be a
+problem for SciPy 1.14.0 too since that release will upgrade from C99
+to C17.
+
+Co-authored-by: Loic Esteve <loic.esteve@ymail.com>
+---
+ mesonbuild/compilers/c.py           | 10 ++++++++++
+ test cases/wasm/1 basic/meson.build |  7 ++++++-
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/mesonbuild/compilers/c.py b/mesonbuild/compilers/c.py
+index 7e2146111563..18b25d46d464 100644
+--- a/mesonbuild/compilers/c.py
++++ b/mesonbuild/compilers/c.py
+@@ -201,6 +201,16 @@ class EmscriptenCCompiler(EmscriptenMixin, ClangCCompiler):
+ 
+     id = 'emscripten'
+ 
++    # Emscripten uses different version numbers than Clang; `emcc -v` will show
++    # the Clang version number used as well (but `emcc --version` does not).
++    # See https://github.com/pyodide/pyodide/discussions/4762 for more on
++    # emcc <--> clang versions. Note that c17/c18/c2x are always available, since
++    # the lowest supported Emscripten version used a new-enough Clang version.
++    _C17_VERSION = '>=1.38.35'
++    _C18_VERSION = '>=1.38.35'
++    _C2X_VERSION = '>=1.38.35'  # 1.38.35 used Clang 9.0.0
++    _C23_VERSION = '>=3.0.0'    # 3.0.0 used Clang 18.0.0
++
+     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
+                  info: 'MachineInfo',
+                  linker: T.Optional['DynamicLinker'] = None,

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -119,6 +119,8 @@ def build_environment(c):
     c.var("make", "nice make -j " + str(cpuccount))
     c.var("configure", "./configure")
     c.var("cmake", "cmake")
+    c.var("meson", "meson")
+    c.var("meson_compile", "{{meson}} compile -j " + str(cpuccount))
 
     c.var("sysroot", c.tmp / f"sysroot.{c.platform}-{c.arch}")
     c.var("build_platform", sysconfig.get_config_var("HOST_GNU_TYPE"))
@@ -224,6 +226,11 @@ def build_environment(c):
         c.var("cmake_system_processor", "x86_64")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ sysroot }}' -DCMAKE_SYSROOT={{ sysroot }}")
 
+        c.var("meson_cross_system", "linux")
+        c.var("meson_cross_kernel", "linux")
+        c.var("meson_cross_cpu_family", "x86_64")
+        c.var("meson_cross_cpu", "x86_64")
+
     elif (c.platform == "linux") and (c.arch == "aarch64"):
 
         llvm(c, clang_args="-target {{ host_platform }} --sysroot {{ sysroot }} -fPIC -pthread")
@@ -234,6 +241,11 @@ def build_environment(c):
         c.var("cmake_system_name", "Linux")
         c.var("cmake_system_processor", "aarch64")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ sysroot }}' -DCMAKE_SYSROOT={{ sysroot }}")
+
+        c.var("meson_cross_system", "linux")
+        c.var("meson_cross_kernel", "linux")
+        c.var("meson_cross_cpu_family", "aarch64")
+        c.var("meson_cross_cpu", "aarch64")
 
     elif (c.platform == "linux") and (c.arch == "i686"):
 
@@ -246,6 +258,11 @@ def build_environment(c):
         c.var("cmake_system_processor", "i386")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ sysroot }}' -DCMAKE_SYSROOT={{ sysroot }}")
 
+        c.var("meson_cross_system", "linux")
+        c.var("meson_cross_kernel", "linux")
+        c.var("meson_cross_cpu_family", "x86")
+        c.var("meson_cross_cpu", "i686")
+
     elif (c.platform == "linux") and (c.arch == "armv7l"):
 
         llvm(c, clang_args="-target {{ host_platform }} --sysroot {{ sysroot }} -fPIC -pthread -mfpu=neon -mfloat-abi=hard")
@@ -256,6 +273,11 @@ def build_environment(c):
         c.var("cmake_system_name", "Linux")
         c.var("cmake_system_processor", "armv7")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ sysroot }}' -DCMAKE_SYSROOT={{ sysroot }}")
+
+        c.var("meson_cross_system", "linux")
+        c.var("meson_cross_kernel", "linux")
+        c.var("meson_cross_cpu_family", "arm")
+        c.var("meson_cross_cpu", "armhf")
 
     elif (c.platform == "windows") and (c.arch == "x86_64"):
 
@@ -271,6 +293,11 @@ def build_environment(c):
         c.var("cmake_system_processor", "x86_64")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ cross }}/llvm-mingw/x86_64-w64-mingw32' -DCMAKE_SYSROOT={{ cross }}/llvm-mingw/x86_64-w64-mingw32")
 
+        c.var("meson_cross_system", "windows")
+        c.var("meson_cross_kernel", "nt")
+        c.var("meson_cross_cpu_family", "x86_64")
+        c.var("meson_cross_cpu", "x86_64")
+
     elif (c.platform == "windows") and (c.arch == "i686"):
 
         llvm(
@@ -285,6 +312,11 @@ def build_environment(c):
         c.var("cmake_system_processor", "i386")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ cross }}/llvm-mingw/i686-w64-mingw32' -DCMAKE_SYSROOT={{ cross }}/llvm-mingw/i686-w64-mingw32")
 
+        c.var("meson_cross_system", "windows")
+        c.var("meson_cross_kernel", "nt")
+        c.var("meson_cross_cpu_family", "x86")
+        c.var("meson_cross_cpu", "i686")
+
     elif (c.platform == "android") and (c.arch == "x86_64"):
 
         android_llvm(c, "x86_64")
@@ -295,6 +327,11 @@ def build_environment(c):
         c.var("cmake_system_processor", "x86_64")
         c.var("android_abi", "x86_64")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH={{ install }} -DCMAKE_TOOLCHAIN_FILE={{cross}}/{{ndk_version}}/build/cmake/android.toolchain.cmake -DANDROID_ABI={{ android_abi }} -DANDROID_PLATFORM=android-21 -DANDROID_USE_LEGACY_TOOLCHAIN_FILE=OFF")
+
+        c.var("meson_cross_system", "android")
+        c.var("meson_cross_kernel", "linux")
+        c.var("meson_cross_cpu_family", "x86_64")
+        c.var("meson_cross_cpu", "x86_64")
 
     elif (c.platform == "android") and (c.arch == "arm64_v8a"):
 
@@ -307,6 +344,11 @@ def build_environment(c):
         c.var("android_abi", "arm64-v8a")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH={{ install }} -DCMAKE_TOOLCHAIN_FILE={{cross}}/{{ndk_version}}/build/cmake/android.toolchain.cmake -DANDROID_ABI={{ android_abi }} -DANDROID_PLATFORM=android-21 -DANDROID_USE_LEGACY_TOOLCHAIN_FILE=OFF")
 
+        c.var("meson_cross_system", "android")
+        c.var("meson_cross_kernel", "linux")
+        c.var("meson_cross_cpu_family", "aarch64")
+        c.var("meson_cross_cpu", "aarch64")
+
     elif (c.platform == "android") and (c.arch == "armeabi_v7a"):
 
         android_llvm(c, "armv7a")
@@ -317,6 +359,11 @@ def build_environment(c):
         c.var("cmake_system_processor", "armv7-a")
         c.var("android_abi", "armeabi-v7a")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH={{ install }} -DCMAKE_TOOLCHAIN_FILE={{cross}}/{{ndk_version}}/build/cmake/android.toolchain.cmake -DANDROID_ABI={{ android_abi }} -DANDROID_PLATFORM=android-21 -DANDROID_USE_LEGACY_TOOLCHAIN_FILE=OFF")
+
+        c.var("meson_cross_system", "android")
+        c.var("meson_cross_kernel", "linux")
+        c.var("meson_cross_cpu_family", "arm")
+        c.var("meson_cross_cpu", "armv7")
 
     elif (c.platform == "mac") and (c.arch == "x86_64"):
 
@@ -333,6 +380,12 @@ def build_environment(c):
         c.var("cmake_system_processor", "x86_64")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ cross }}/sdk' -DCMAKE_SYSROOT={{ cross }}/sdk")
 
+        c.var("meson_cross_system", "darwin")
+        c.var("meson_cross_subsystem", "macos")
+        c.var("meson_cross_kernel", "xnu")
+        c.var("meson_cross_cpu_family", "x86_64")
+        c.var("meson_cross_cpu", "x86_64")
+
     elif (c.platform == "mac") and (c.arch == "arm64"):
 
         llvm(
@@ -348,6 +401,12 @@ def build_environment(c):
         c.var("cmake_system_processor", "aarch64")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ cross }}/sdk' -DCMAKE_SYSROOT={{ cross }}/sdk")
 
+        c.var("meson_cross_system", "darwin")
+        c.var("meson_cross_subsystem", "macos")
+        c.var("meson_cross_kernel", "xnu")
+        c.var("meson_cross_cpu_family", "aarch64")
+        c.var("meson_cross_cpu", "arm64")
+
     elif (c.platform == "ios") and (c.arch == "arm64"):
 
         llvm(
@@ -361,6 +420,12 @@ def build_environment(c):
         c.var("cmake_system_name", "Darwin")
         c.var("cmake_system_processor", "aarch64")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ cross }}/sdk' -DCMAKE_SYSROOT={{ cross }}/sdk")
+
+        c.var("meson_cross_system", "darwin")
+        c.var("meson_cross_subsystem", "ios")
+        c.var("meson_cross_kernel", "xnu")
+        c.var("meson_cross_cpu_family", "aarch64")
+        c.var("meson_cross_cpu", "aarch64")
 
     elif (c.platform == "ios") and (c.arch == "sim-arm64"):
 
@@ -376,6 +441,12 @@ def build_environment(c):
         c.var("cmake_system_processor", "aarch64")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ cross }}/sdk' -DCMAKE_SYSROOT={{ cross }}/sdk")
 
+        c.var("meson_cross_system", "darwin")
+        c.var("meson_cross_subsystem", "ios-simulator")
+        c.var("meson_cross_kernel", "xnu")
+        c.var("meson_cross_cpu_family", "aarch64")
+        c.var("meson_cross_cpu", "aarch64")
+
     elif (c.platform == "ios") and (c.arch == "sim-x86_64"):
 
         llvm(
@@ -389,6 +460,12 @@ def build_environment(c):
         c.var("cmake_system_name", "Darwin")
         c.var("cmake_system_processor", "x86_64")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH='{{ install }};{{ cross }}/sdk' -DCMAKE_SYSROOT={{ cross }}/sdk")
+
+        c.var("meson_cross_system", "darwin")
+        c.var("meson_cross_subsystem", "ios-simulator")
+        c.var("meson_cross_kernel", "xnu")
+        c.var("meson_cross_cpu_family", "x86_64")
+        c.var("meson_cross_cpu", "x86_64")
 
     elif (c.platform == "web") and (c.arch == "wasm") and (c.name != "web"):
 
@@ -430,6 +507,11 @@ def build_environment(c):
         c.var("cmake_system_processor", "generic")
         c.var("cmake_args", "-DCMAKE_FIND_ROOT_PATH={{ install }}")
 
+        c.var("meson_cross_system", "emscripten")
+        c.var("meson_cross_kernel", "none")
+        c.var("meson_cross_cpu_family", "wasm32")
+        c.var("meson_cross_cpu", "wasm32")
+
 
     if c.kind not in ( "host", "host-python", "cross" ):
         c.env("PKG_CONFIG_LIBDIR", "{{ install }}/lib/pkgconfig:{{ PKG_CONFIG_LIBDIR }}")
@@ -441,6 +523,17 @@ def build_environment(c):
     c.env("CXXFLAGS", "{{ CFLAGS }}")
 
     c.var("cmake", "{{cmake}} {{ cmake_args }} -DCMAKE_PROJECT_INCLUDE_BEFORE={{root}}/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release")
+
+    if not "meson_cross_subsystem" in c.variables:
+        c.var("meson_cross_subsystem", "{{ meson_cross_system }} ")
+
+    if c.kind not in ( "host", "host-python", "cross" ):
+        c.var("meson_build_kind", "cross")
+    else:
+        c.var("meson_build_kind", "native")
+
+    c.var("meson_config_file", "{{ install }}/meson_{{meson_build_kind}}_file.txt")
+    c.var("meson_args", "--{{meson_build_kind}}-file={{meson_config_file}} --buildtype=release -Dc_std=gnu17 -Dcpp_std=gnu++17")
 
     # Used by zlib.
     if c.kind != "host":

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -119,8 +119,8 @@ def build_environment(c):
     c.var("make", "nice make -j " + str(cpuccount))
     c.var("configure", "./configure")
     c.var("cmake", "cmake")
-    c.var("meson", "meson")
-    c.var("meson_compile", "{{meson}} compile -j " + str(cpuccount))
+    c.var("meson_configure", "meson setup")
+    c.var("meson_compile", "meson compile -j " + str(cpuccount))
 
     c.var("sysroot", c.tmp / f"sysroot.{c.platform}-{c.arch}")
     c.var("build_platform", sysconfig.get_config_var("HOST_GNU_TYPE"))

--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -119,6 +119,7 @@ def build_environment(c):
     c.var("make", "nice make -j " + str(cpuccount))
     c.var("configure", "./configure")
     c.var("cmake", "cmake")
+
     c.var("meson_configure", "meson setup")
     c.var("meson_compile", "meson compile -j " + str(cpuccount))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 typing==3.7.4.3
 urllib3==2.0.4
+meson>=0.62.0

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -4,6 +4,7 @@ from renpybuild.context import Context
 from . import cython
 
 from . import env_sh
+from . import meson_setup
 
 from . import sysroot
 from . import toolchain

--- a/tasks/meson_setup.py
+++ b/tasks/meson_setup.py
@@ -1,6 +1,16 @@
 from renpybuild.context import Context
 from renpybuild.task import task
 
+@task(kind="host", platforms="all")
+def patch_meson(c: Context):
+
+    # See https://github.com/pyodide/pyodide/discussions/4762, will be fixed in
+    # meson 1.4.1
+    import mesonbuild.coredata
+    if mesonbuild.coredata.version <= '1.4.0':
+        c.chdir(f"{mesonbuild.__path__[0]}/..")
+        c.patch("meson-fix-emscripten-std.patch")
+
 @task(platforms="all")
 def unpack(c: Context):
 

--- a/tasks/meson_setup.py
+++ b/tasks/meson_setup.py
@@ -1,0 +1,61 @@
+from renpybuild.context import Context
+from renpybuild.task import task
+
+@task(platforms="all")
+def unpack(c: Context):
+
+    # Remove flags for compiler and set them using meson's method
+    for compiler_var in ("CC", "CXX", "CPP"):
+        updated_var = c.environ[compiler_var].replace("-fuse-ld=lld -Wno-unused-command-line-argument ", "")
+
+        if compiler_var == "CXX":
+            updated_var = updated_var.replace(" -std=gnu++17", "")
+        else:
+            updated_var = updated_var.replace(" -std=gnu17", "")
+
+        c.env(compiler_var, updated_var)
+
+    # Set linker type
+    c.env("CC_LD", "lld")
+    c.env("CXX_LD", "lld")
+
+    if c.platform == "mac" or c.platform == "ios":
+        c.env("OBJC_LD", "lld")
+        c.env("OBJCXX_LD", "lld")
+
+    c.run("""
+        {{ meson }} env2mfile --cross
+        -o "{{ install }}/meson_cross_file.txt"
+        --system={{ meson_cross_system }}
+        --subsystem={{ meson_cross_subsystem }}
+        --kernel={{ meson_cross_kernel }}
+        --cpu-family={{ meson_cross_cpu_family }}
+        --cpu={{ meson_cross_cpu }}
+        """)
+
+    # Delete option if its value is "none"
+    c.run(""" sed -i "/'none'/d" "{{ install }}/meson_cross_file.txt" """)
+
+@task(kind="host", platforms="all")
+def unpack(c: Context):
+
+    # Remove flags for compiler and set them using meson's method
+    for compiler_var in ("CC", "CXX", "CPP"):
+        updated_var = c.environ[compiler_var].replace("-fuse-ld=lld -Wno-unused-command-line-argument ", "")
+
+        if compiler_var == "CC":
+            updated_var = updated_var.replace(" -std=gnu17", "")
+        elif compiler_var == "CXX":
+            updated_var = updated_var.replace(" -std=gnu++17", "")
+
+        c.env(compiler_var, updated_var)
+
+    # Set linker type
+    c.env("CC_LD", "lld")
+    c.env("CXX_LD", "lld")
+
+    if c.platform == "mac" or c.platform == "ios":
+        c.env("OBJC_LD", "lld")
+        c.env("OBJCXX_LD", "lld")
+
+    c.run(""" {{ meson }} env2mfile --native -o "{{ install }}/meson_native_file.txt" """)

--- a/tasks/meson_setup.py
+++ b/tasks/meson_setup.py
@@ -5,10 +5,17 @@ from renpybuild.task import task
 def patch_meson(c: Context):
 
     # See https://github.com/pyodide/pyodide/discussions/4762, will be fixed in
-    # meson 1.4.1
+    # meson 1.4.1, this is a temporary solution and shouldn't be used for a long time
     import mesonbuild.coredata
+    import os
+
     if mesonbuild.coredata.version <= '1.4.0':
         c.chdir(f"{mesonbuild.__path__[0]}/..")
+        backup_file = c.path("{{ tmp }}/mesonbuild_compilers_c.py.orig")
+        if not os.path.exists(backup_file):
+            c.run(f"cp mesonbuild/compilers/c.py {backup_file}")
+
+        c.run(f"cp {backup_file} mesonbuild/compilers/c.py")
         c.patch("meson-fix-emscripten-std.patch")
 
 @task(platforms="all")
@@ -34,7 +41,7 @@ def unpack(c: Context):
         c.env("OBJCXX_LD", "lld")
 
     c.run("""
-        {{ meson }} env2mfile --cross
+        meson env2mfile --cross
         -o "{{ install }}/meson_cross_file.txt"
         --system={{ meson_cross_system }}
         --subsystem={{ meson_cross_subsystem }}
@@ -68,4 +75,4 @@ def unpack(c: Context):
         c.env("OBJC_LD", "lld")
         c.env("OBJCXX_LD", "lld")
 
-    c.run(""" {{ meson }} env2mfile --native -o "{{ install }}/meson_native_file.txt" """)
+    c.run("""meson env2mfile --native -o "{{ install }}/meson_native_file.txt" """)


### PR DESCRIPTION
To integrate meson build system, a cross-file is required, the easiest way to do this is to use meson's `env2mfile` command, which eliminates the need to generate a cross-file manually.

 `env2mfile` requires meson 0.62.0, but Ubuntu 22.04's meson version is 0.61.2, so using pip to install the latest version of meson

For maintaining each platform and architecture, the following variables need to be set to generate the cross-file:

- `meson_cross_system`: https://mesonbuild.com/Reference-tables.html#operating-system-names
- `meson_cross_subsystem`: Not needed, if not set, will be set as `meson_cross_system`, https://mesonbuild.com/Reference-tables.html#subsystem-names-since-120
- `meson_cross_kernel`: https://mesonbuild.com/Reference-tables.html#kernel-names-since-120
- `meson_cross_cpu_family`: https://mesonbuild.com/Reference-tables.html#cpu-families
- `meson_cross_cpu`: There is no reference for, so it has to manually find the appropriate value

There is a bug in meson 1.4.0, which made not able to use meson's `-Dc_std`, `-Dcpp_std` to set c/cxx default standard version, so adding a patch from upstream to fix it, when meson 1.4.1 is released, the patch should be removed.