### PR TITLE
[Web] Periodically check if the persistent data needs to be stored

### DIFF
--- a/runtime/web/renpy-pre.js
+++ b/runtime/web/renpy-pre.js
@@ -47,7 +47,7 @@ Module.preRun = Module.preRun || [ ];
     // The status message.
     let statusText = "";
 
-    // How long before the status div starts hiding, in seconds.
+    // How long before the status div starts hiding, in ms.
     const STATUS_TIMEOUT = 5000;
 
     // The last time the progress was updated.
@@ -58,6 +58,9 @@ Module.preRun = Module.preRun || [ ];
 
     // Should output only go to the console?
     let printConsoleOnly = false;
+
+    // Time between persistent data change checks, in ms.
+    const PERSIST_PERIOD = 5000;
 
     /**
      * Hide the status div. Once it's hidden, clears the status text.
@@ -202,6 +205,20 @@ Module.preRun = Module.preRun || [ ];
 
     }
 
+    /** Check if the persistent data has changed, and store it if so.
+     */
+    async function updatePersistent() {
+        try {
+            await renpy_exec('renpy.persistent.update()');
+        } finally {
+            schedulePersistentUpdate();
+        }
+    }
+
+    function schedulePersistentUpdate() {
+        setTimeout(updatePersistent, PERSIST_PERIOD);
+    }
+
     window.progress = progress;
 
     Module.print = printMessage;
@@ -263,6 +280,7 @@ Module.preRun = Module.preRun || [ ];
         presplash.remove();
         cancelStatusTimeout();
         hideStatus();
+        schedulePersistentUpdate();
     };
 
     window.atExit = () => {


### PR DESCRIPTION
The persistent data is generally flushed to disk when Ren'Py exits. This is not possible on Web, because no code can be executed after the "beforeunload" event that the browser sends before leaving the page. IIRC this event is handled correctly by emscripten, but this makes sdl2 and/or Ren'Py post another event in their internal events queue which can never processed then.

The current workaround for Web is to flush the persistent data each time a manual save is made. This is better than nothing, but that's pretty frustrating when you change some preferences in a game, then start playing it, decide to reload the page and realize all your preferences have been reset because the persistent data has not been stored to disk.

So, this commit periodically checks for changes in the persistent data and stores it to the Web storage if so. The current period is 5 seconds, and it takes ~50 ms on my PC to check for that, so it should not impact the performances too much?

On a side note, `renpy.persistent.update()` calls `synfc()` twice, but that's easy to fix.