### PR TITLE
Increase the stack size to 128 KB

### DIFF
--- a/tasks/renpython.py
+++ b/tasks/renpython.py
@@ -612,6 +612,7 @@ def link_web(c: Context):
     -sASYNCIFY_ONLY="{{ asyncify_only }}"
     -sINITIAL_MEMORY=192MB
     -sALLOW_MEMORY_GROWTH=1
+    -sSTACK_SIZE=128KB
 
     -sEXPORTED_FUNCTIONS=['_main']
 


### PR DESCRIPTION
It is 64 KB by default, but aom needs at least 64800 bytes for decoding frames (see the arrays allocated in ["av1/common/restoration.c"](https://aomedia.googlesource.com/aom/+/refs/tags/v3.5.0/av1/common/restoration.c) with size `RESTORATION_PROC_UNIT_PELS`). IMHO, allocating 64 KB from the stack is criminal, but that's Google code, so I guess they know better...
We already allocate at least 200 MB for the memory, so using 128 KB for the stack sounds reasonable (it is 1 MB by default on some x86 OS for instance).

The cause of the avif decode crash shows up when compiling the web version with `-sASSERTIONS=2` (which I didn't use of course, because I love spending hours debugging wasm instructions🥴). Also, the "-fsanitize" build options that are supposed to debug memory problems don't work at all with Ren'Py.

On a side note, upgrading libavif and aom to the latest version (v1.1.1 and v3.10.0 respectively) seems to work well with Ren'Py (but the `AVIF_CODEC_AOM` cmake parameter for libavif needs to be set to "SYSTEM" instead of "1" now).

Fix renpy/renpy#5871

(New PR against the fix branch this time)