### PR TITLE
fix: self-builded `web`

### DIFF
--- a/tasks/pythonlib.py
+++ b/tasks/pythonlib.py
@@ -544,10 +544,10 @@ def python3(c: Context):
     c.copy("{{ runtime }}/site3.py", "{{ distlib }}/{{ pythonver }}/sitecustomize.py")
 
     import socket
-    if socket.gethostname() == "eileen":
-        with open(c.path("{{ distlib }}/{{ pythonver }}/sitecustomize.py"), "a") as f:
-            f.write("\n")
-            f.write("import site\n")
+    with open(c.path("{{ distlib }}/{{ pythonver }}/sitecustomize.py"), "a") as f:
+        f.write("\n")
+        f.write("import site\n")
+        if socket.gethostname() == "eileen":
             f.write("site.renpy_build_official = True\n")
 
     c.compile("{{ distlib }}/{{ pythonver }}/sitecustomize.py")


### PR DESCRIPTION
Causes error without `import site` in `sitecustomize.py`:

![image](https://github.com/user-attachments/assets/230771ab-cbe8-4e6d-b6e9-6fcb4b38b528)
