### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Requirements
 Ren'Py Build requires a computer running Ubuntu 24.04. While it can run on
 a desktop computer, portions of the build process must run at root, and the
 whole process has security implications. My recommendation is to create a
-virtual machine, install Ubuntu 42.04 on it, and run this procedure on
+virtual machine, install Ubuntu 24.04 on it, and run this procedure on
 that machine.
 
 The virtual machine must be provisioned with at least 64 GB of disk space.


### PR DESCRIPTION
This pull request changes "Ubuntu 42.04" to "Ubuntu 24.04" in README.rst. This typo was introduced in d74734b32877249f57fb68210fc80e2696351bd3.