### PR TITLE
Remove python2-dev apt dependency from prepare.sh

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -11,7 +11,7 @@ BASE="$ROOT"
 sudo apt-get install -y git build-essential ccache unzip autoconf autoconf-archive automake libtool-bin
 
 # Needed to build python things.
-sudo apt-get install -y python2-dev python3-dev python3-venv
+sudo apt-get install -y python3-dev python3-venv
 
 # Needed to install python2 pip
 sudo apt-get install -y curl


### PR DESCRIPTION
Current script approach is crashing when doing clean installation in Ubuntu-24.04.
We don't need python2-dev since it cannot be installed for recommended Ubuntu-24.04. 
Related to #101 https://github.com/renpy/renpy-build/issues/101#issuecomment-1827028851