### PR TITLE
py312: Add missing functions to asyncify

### DIFF
--- a/tasks/renpython.py
+++ b/tasks/renpython.py
@@ -555,6 +555,10 @@ def link_web(c: Context):
         'byn$fpcast-emu$method_vectorcall',
         'byn$fpcast-emu$slot_tp_call',
         'byn$fpcast-emu$opfunc_*',
+        '__Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS',
+        'byn$fpcast-emu$__Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS',
+        'partial_vectorcall',
+        'byn$fpcast-emu$partial_vectorcall',
         ]
 
     c.var("asyncify_only", repr(asyncify_only).replace(" ", ""))


### PR DESCRIPTION
There are 2 new functions introduced by Python 3.12 that need to be added to "asyncify_only". Each function in this list must only be called from functions that are in this list as well and these new functions appeared in the call stack to asyncified function, hence the crashes.

There is [a way](https://emscripten.org/docs/tools_reference/settings_reference.html#asyncify-propagate-add) to let Binaryen find the calls dependencies at compile time but it only works when using ASYNCIFY_ADD (not ASYNCIFY_ONLY) and we can't define both, so we have to find the dependencies manually😔

I've checked the tutorial works without crashing on Web after applying this PR and that pressing "H" works.

Fixes renpy/renpy#6104