### PR TITLE
Update minor Cython version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cython==3.0.11
+Cython==3.0.12
 pefile==2022.5.30
 alabaster==0.7.16
 babel==2.16.0


### PR DESCRIPTION
https://github.com/renpy/renpy/issues/6448 needs fix for https://github.com/cython/cython/issues/6094 which shipped in 3.0.12.

Just bumped the minor version for now as we're close to release.