### PR TITLE
Restore file mtime when extracting game.zip

### DIFF
--- a/runtime/site3.py
+++ b/runtime/site3.py
@@ -167,6 +167,7 @@ def unpack_web():
 
     import zipfile
     import emscripten
+    import calendar
 
     print("")
     print("Unpacking...")
@@ -177,6 +178,10 @@ def unpack_web():
 
     for i, zi in enumerate(infolist):
         zf.extract(zi, "/")
+
+        # Restore file modification time as zipfile does not
+        mtime = calendar.timegm(zi.date_time + (0, 0, -1))
+        os.utime("/" + zi.filename, (mtime, mtime))
 
         if i % 25 == 0 or i == len(infolist) - 1:
             emscripten.run_script("""progress(%d, %d);""" % (i+1, len(infolist)))


### PR DESCRIPTION
The zipfile lib does not restore the files modification time when extracting a ZIP file. This has an impact on Python as the PY file mtime is stored in the PYC header so that Python can check if the PYC file needs to be recompiled before loading it: if the mtime for the PY file does not match the value in the PYC header, the file is recompiled. So on Web, all the PY files are recompiled, which increases the game load time by at least 10% on my tests.

This commit update the file mtime after extraction using the value in the ZIP entry to prevent that issue.

There is still one big issue here: the mtime field is stored as units of 2 seconds in ZIP files, so the number of seconds in that field is always an even number. If the PY file mtime is an odd number of seconds, then the value in the PYC header will not match the value in the emscripten FS, so the PY file will still be recompiled at load time.
Also, most PY files have the same mtime in Ren'Py SDK releases, so because of the 2 seconds unit in ZIP file, either all or none of the PY files will be recompiled when loading the game.

The only solution to prevent that is to use another file format than ZIP. The TAR.GZ file format seems to be a better alternative for that, and it is supported by Python through the tarfile standard library. I suggest to switch to it and can work on the changes.

These changes will also be useful if the idea to use mtime instead of hash from renpy/renpy#6328 is implemented.