### PR TITLE
Add PyRun_StringFlags to the list of asyncify functions

### DIFF
--- a/tasks/renpython.py
+++ b/tasks/renpython.py
@@ -533,6 +533,7 @@ def link_web(c: Context):
         '_PyObject_MakeTpCall',
         '_PyRun_AnyFileObject',
         '_PyRun_SimpleFileObject',
+        'PyRun_StringFlags',
         '_PyVectorcall_Call',
         '__pyx_pw_10emscripten_19sleep',
         'builtin___import__',


### PR DESCRIPTION
Fix renpy/renpy#6542

For the records, here are the steps I use to find such missing functions:
1. Open the game in Chrome.
1. Open devtools and maybe reload the page.
1. Enter that code in the console (it records the stack trace each time Asyncify.handleSleep() is called for later analysis):
```js
window._as_handleSleep = Asyncify.handleSleep;
Error.stackTraceLimit = 100
Asyncify.handleSleep = function(...args) {window.sleep_trace = new Error(); return window._as_handleSleep(...args);}
```
4. Trigger the crash
1. Check the stack trace in `sleep_trace.trace`, replace `wasm-function[N]` with the actual function names using "index.html.symbols" and print the name of each function called:
```js
func_names = {}; (await (await fetch('index.html.symbols')).text()).split('\n').forEach(line => {p = line.indexOf(':'); func_names[line.slice(0, p)] = line.slice(p + 1, 1000)})
trace_funcs = new Set(); sleep_trace.stack.split('\n').forEach(line => {m = line.match(/wasm-function\[(\d+)\]/); if(m) trace_funcs.add(func_names[m[1]])})
console.log([...trace_funcs.values()].sort().join('\n'))
```
6. Find the functions that are not part of the `asyncify_only` list in "tasks/renpython.py"
