### PR TITLE
Fix pkg-config search path for cmake when building wasm

### DIFF
--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -395,6 +395,7 @@ def build_environment(c):
         c.env("PKG_CONFIG_LIBDIR", "{{cross}}/upstream/emscripten/cache/sysroot/lib/pkgconfig:{{cross}}/upstream/emscripten/system/lib/pkgconfig")
         # Add pkg-file search path for emscripten, since emscripten locked PKG_CONFIG_LIBDIR
         c.env("EM_PKG_CONFIG_PATH", "{{ install }}/lib/pkgconfig")
+        c.env("PKG_CONFIG_PATH", "{{ EM_PKG_CONFIG_PATH }}")
 
         # Tell emcc and em++ to use ccache when building
         c.env("EM_COMPILER_WRAPPER", "/usr/bin/ccache")


### PR DESCRIPTION
Emscripten's cmake warpper `emcmake` won't convert environment `EM_PKG_CONFIG_PATH` to `PKG_CONFIG_PATH`, which makes cmake's `pkg_check_modules()` function can't find dependencies in install dir.

For example, `libavif` will not find `libsharpyuv`
<details><summary>Details</summary>
<p>

```
build-libavif.web-wasm running in /home/aa/Builds/renpy-build/tmp/build/libavif.web-wasm ...
configure: cmake -G Ninja -DCMAKE_FIND_ROOT_PATH=/home/aa/Builds/renpy-build/tmp/install.web-wasm -DCMAKE_SYSTEM_NAME=Emscripten -DCMAKE_SYSTEM_PROCESSOR=generic -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY -DCMAKE_PROJECT_INCLUDE_BEFORE=/home/aa/Builds/renpy-build/tools/cmake_build_variables.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_PARALLEL_LEVEL=12 -DCMAKE_INSTALL_PREFIX=/home/aa/Builds/renpy-build/tmp/install.web-wasm -DAVIF_CODEC_AOM=1 -DAVIF_CODEC_AOM_ENCODE=0 -DBUILD_SHARED_LIBS=0 /home/aa/Builds/renpy-build/tmp/source/libavif -DCMAKE_TOOLCHAIN_FILE=/home/aa/Builds/renpy-build/tmp/cross.web-wasm/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake -DCMAKE_CROSSCOMPILING_EMULATOR=/home/aa/Builds/renpy-build/tmp/cross.web-wasm/node/22.16.0_64bit/bin/node
-- libavif: Enabling warnings for Clang
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Checking for module 'libyuv'
--   Package 'libyuv', required by 'virtual:world', not found
-- libavif: libyuv (1878) found; libyuv-based fast paths enabled.
-- Checking for module 'libsharpyuv'
--   Package 'libsharpyuv', required by 'virtual:world', not found
-- libavif: libsharpyuv not found

``` 

</p>
</details> 

This PR's solution is using `emmake` to warp `pkg-config`, so environments like `EM_PKG_CONFIG_PATH` could work correctly in cmake. This is the [recommended method](https://github.com/emscripten-core/emscripten/blob/a4d0dbc7fcc6a7a863315c4fa10a42f39bbd7a51/ChangeLog.md?plain=1#L118) by Emscripten.