### PR TITLE
Git clone depth

### DIFF
--- a/renpybuild/context.py
+++ b/renpybuild/context.py
@@ -15,12 +15,14 @@ from typing import Any
 # Monkeypatch copytree to fix a problem with ignore_dangling_symlinks.
 old_copytree = shutil.copytree
 
+
 def copytree(*args, **kwargs):
     if len(args) < 6:
         # ignore_dangling_symlinks is not passed by pos
         kwargs.setdefault("ignore_dangling_symlinks", True)
 
     return old_copytree(*args, **kwargs)
+
 
 shutil.copytree = copytree
 
@@ -34,57 +36,57 @@ class Context:
     """
 
     # The platform. One of "linux", "windows", "mac", "android", "ios", or "web".
-    platform : str
+    platform: str
 
     # The architecture. Varies based on the platform.
-    arch : str
+    arch: str
 
     # The version of Python, one of "2" or "3"
-    python : str
+    python: str
 
     # The root directory of the build.
-    root : Path
+    root: Path
 
     # The arguments passed to the build by argparse.
-    args : Any
+    args: Any
 
     # Maps containing the environment and non-environment variables. Environment
     # variables are passed to subprocesses, while non-environment variables are
     # only used for expansion.
-    environ : dict[str, str]
-    variables : dict[str, str]
+    environ: dict[str, str]
+    variables: dict[str, str]
 
     # The local temporary directory.
-    tmp : Path
+    tmp: Path
 
     # The kind of task.
-    kind : str
+    kind: str
 
     # The name of the function that the task is defined in.
-    task : str
+    task: str
 
     # The name of the module that the task is defined in.
-    name : str
+    name: str
 
     # A unique name for this the task being executed.
-    task_name : str
+    task_name: str
 
     # The name of the directory the task will run in.
-    dir_name : str
+    dir_name: str
 
     # The path to the directory builds will be placed in.
-    build : Path
+    build: Path
 
     # The current directory the task will run in.
-    cwd : Path
+    cwd: Path
 
     # The place to install to.
-    install : Path
+    install: Path
 
     # More paths.
     renpy: Path
 
-    def __init__(self, platform : str, arch : str, python : str, root : Path, args : Any):
+    def __init__(self, platform: str, arch: str, python: str, root: Path, args: Any):
 
         self.platform = platform
         self.arch = arch
@@ -93,7 +95,7 @@ class Context:
         self.args = args
 
         self.environ = dict(os.environ)
-        self.variables = { }
+        self.variables = {}
 
         # The local temporary directory.
         self.tmp = self.root / os.environ.get("RENPY_BUILD_TMP", "tmp")
@@ -134,8 +136,7 @@ class Context:
         # Python version specific storage.
         self.var("pytmp", self.tmp / ("py" + python))
 
-
-    def set_names(self, kind : str, task : str, name : str):
+    def set_names(self, kind: str, task: str, name: str):
         """
         This is used to past the task-specific names into the context.
         """
@@ -229,7 +230,7 @@ class Context:
 
         renpybuild.run.build_environment(self)
 
-    def expand(self, s : str, **kwargs) -> str:
+    def expand(self, s: str, **kwargs) -> str:
         """
         Expands `s` as a jinja template.
         """
@@ -239,12 +240,12 @@ class Context:
         variables = dict()
         variables.update(self.environ)
         variables.update(self.variables)
-        variables.update({ "c" : self })
+        variables.update({"c": self})
         variables.update(kwargs)
 
         return template.render(**variables)
 
-    def generate(self, src : str, dest : str, **kwargs):
+    def generate(self, src: str, dest: str, **kwargs):
         """
         Loads in `src`, a template file, substitutes in ``kwargs`` and all
         the other variables that are defined, and writes it out into ``dest``.
@@ -271,15 +272,14 @@ class Context:
 
         self.path(dest).write_text(text)
 
-
-    def env(self, variable : str, value : str|Path):
+    def env(self, variable: str, value: str | Path):
         """
         Adds environment variable `variable` with `value`.
         """
 
         self.environ[variable] = self.expand(str(value))
 
-    def var(self, variable : str, value : str|Path, expand=True):
+    def var(self, variable: str, value: str | Path, expand=True):
         """
         Adds a non-environment `variable` with `value`.
         """
@@ -289,7 +289,7 @@ class Context:
         else:
             self.variables[variable] = str(value)
 
-    def get(self, variable : str) -> str:
+    def get(self, variable: str) -> str:
         """
         Returns the value of `variable`.
         """
@@ -299,14 +299,14 @@ class Context:
 
         raise Exception(f"Unknown variable {variable!r}.")
 
-    def chdir(self, d : str):
+    def chdir(self, d: str):
         """
         Changes the directory to `d`.
         """
 
         self.cwd = self.cwd / self.expand(d)
 
-    def run(self, command : str, verbose : bool=False, quiet : bool=False, **kwargs):
+    def run(self, command: str, verbose: bool = False, quiet: bool = False, **kwargs):
         """
         Runs `command`, and checks that the result is 0.
 
@@ -330,7 +330,7 @@ class Context:
 
         return renpybuild.run.RunGroup(self)
 
-    def clean(self, d : str="{{build}}"):
+    def clean(self, d: str = "{{build}}"):
         """
         Empties the named directory.
         """
@@ -345,14 +345,14 @@ class Context:
 
         p.mkdir(exist_ok=True, parents=True)
 
-    def path(self, p : str) -> Path:
+    def path(self, p: str) -> Path:
         """
         Returns a path object for `p`.
         """
 
         return self.cwd / self.expand(p)
 
-    def patch(self, fn : str, p : int=1):
+    def patch(self, fn: str, p: int = 1):
         """
         Applies the patch in `fn`.
 
@@ -365,9 +365,9 @@ class Context:
         with open(fpath, "rb") as f:
             patch = f.read()
 
-        subprocess.run([ "patch", "-p%d" % p ], input=patch, cwd=self.cwd, check=True)
+        subprocess.run(["patch", "-p%d" % p], input=patch, cwd=self.cwd, check=True)
 
-    def patchdir(self, dn : str):
+    def patchdir(self, dn: str):
         """
         Applies all the patches in `dn`.
         """
@@ -378,22 +378,21 @@ class Context:
         patches.sort()
 
         for fn in patches:
-
             print("Applying", fn.name)
 
             with open(fn, "rb") as f:
                 patch = f.read()
 
-            subprocess.run([ "patch", "-p1" ], input=patch, cwd=self.cwd, check=True)
+            subprocess.run(["patch", "-p1"], input=patch, cwd=self.cwd, check=True)
 
-    def copy(self, src : str, dst : str):
+    def copy(self, src: str, dst: str):
         """
         Copies `src` to `dst`.
         """
 
         shutil.copy(self.path(src), self.path(dst))
 
-    def include(self, path : str):
+    def include(self, path: str):
         """
         Adds an include to the C compiler include path.
         """
@@ -408,7 +407,7 @@ class Context:
             self.env("CFLAGS", "{{ CFLAGS }} -I" + path)
             self.env("CXXFLAGS", "{{ CXXFLAGS }} -I" + path)
 
-    def copytree(self, src : str, dst : str):
+    def copytree(self, src: str, dst: str):
         """
         Copies the directory `src` to `dst`. If `dst` exists, it is removed.
         """
@@ -423,7 +422,7 @@ class Context:
 
         shutil.copytree(srcpath, dstpath)
 
-    def rmtree(self, d : str):
+    def rmtree(self, d: str):
         """
         Removes the directory `d`.
         """
@@ -435,7 +434,7 @@ class Context:
         elif dpath.exists():
             shutil.rmtree(dpath)
 
-    def unlink(self, fn : str):
+    def unlink(self, fn: str):
         """
         Removes the file `fn`.
         """
@@ -444,7 +443,7 @@ class Context:
         if fnpath.exists():
             fnpath.unlink()
 
-    def symlink(self, src : str, dst : str):
+    def symlink(self, src: str, dst: str):
         """
         Creates a symlink from `src` to `dst`.
         """
@@ -454,7 +453,7 @@ class Context:
 
         dstpath.symlink_to(srcpath)
 
-    def compile(self, src : str|Path):
+    def compile(self, src: str | Path):
         """
         Compiles py files to pyc files, and elides the build path.
         """
@@ -471,12 +470,11 @@ class Context:
             flags = f"-d {dst} -fq --invalidation-mode unchecked-hash"
 
             if src.endswith(".py"):
-                flags = f'-b {flags}'
+                flags = f"-b {flags}"
 
         self.run(command, flags=flags, src=src)
 
-
-    def download(self, url : str, fn : str):
+    def download(self, url: str, fn: str):
         """
         Downloads `url` to tmp/tars/`fn`.
         """
@@ -494,7 +492,44 @@ class Context:
         with requests.get(url, stream=True) as r:
             r.raise_for_status()
             with open(dest.with_suffix(".tmp"), "wb") as f:
-                for chunk in r.iter_content(chunk_size=1024*1024):
+                for chunk in r.iter_content(chunk_size=1024 * 1024):
                     f.write(chunk)
 
         dest.with_suffix(".tmp").rename(dest)
+
+    def clone(
+        self,
+        url: str,
+        options: str = "",
+        *,
+        directory: str = "",
+        minimal: bool = True,
+        submodules: bool = False,
+    ):
+        """
+        Clones the repository at `url` into the current directory.
+
+        `options`
+            Options to pass to git clone.
+
+        `directory`
+            The directory to clone into.
+
+        `minimal`
+            If true, automatically applies options to minimize download size.
+
+        `submodules`
+            If true, also clones submodules recursively.
+        """
+
+        url = self.expand(url)
+        options = self.expand(options)
+        directory = self.expand(directory)
+
+        if minimal:
+            options = f"--depth 1 --no-tags --single-branch --shallow-submodules {options}"
+
+        if submodules:
+            options = f"--recurse-submodules {options}"
+
+        self.run(f"git clone {options} {url} {directory}")

--- a/tasks/aom.py
+++ b/tasks/aom.py
@@ -2,21 +2,11 @@ from renpybuild.context import Context
 from renpybuild.task import task
 
 @task(kind="host", platforms="all")
-def download(c : Context):
-
-    if c.path("{{ tmp }}/source/aom").exists():
-        c.chdir("{{ tmp }}/source/aom")
-        c.run("git checkout master")
-        c.run("git pull")
-        c.run("git checkout v3.5.0")
-        return
-
+def download(c: Context):
     c.clean("{{ tmp }}/source/aom")
     c.chdir("{{ tmp }}/source")
 
-    c.run("git clone https://aomedia.googlesource.com/aom")
-    c.chdir("{{ tmp }}/source/aom")
-    c.run("git checkout v3.5.0")
+    c.clone("https://aomedia.googlesource.com/aom", "--branch v3.5.0")
 
 @task(platforms="all")
 def build(c : Context):

--- a/tasks/assimp.py
+++ b/tasks/assimp.py
@@ -6,7 +6,7 @@ def download(c : Context):
     c.clean("{{ tmp }}/source/assimp")
     c.chdir("{{ tmp }}/source")
 
-    c.run("git clone --depth 1 --branch v5.4.3 https://github.com/assimp/assimp")
+    c.clone("https://github.com/assimp/assimp", "--branch v5.4.3")
 
     c.chdir("assimp")
     c.patch("assimp.diff")

--- a/tasks/libavif.py
+++ b/tasks/libavif.py
@@ -2,11 +2,11 @@ from renpybuild.context import Context
 from renpybuild.task import task
 
 @task(kind="host", platforms="all")
-def download(c : Context):
+def download(c: Context):
     c.clean("{{ tmp }}/source/libavif")
     c.chdir("{{ tmp }}/source")
 
-    c.run("git clone --branch v0.11.1 https://github.com/AOMediaCodec/libavif")
+    c.clone("https://github.com/AOMediaCodec/libavif", "--branch v0.11.1")
 
 @task(platforms="all")
 def build(c : Context):

--- a/tasks/libyuv.py
+++ b/tasks/libyuv.py
@@ -6,12 +6,21 @@ from renpybuild.task import task
 def download(c: Context):
     c.var("commit", "d23308a2a7442be8e559b1b471862fd7588d6a57")
 
-    c.clean("{{ tmp }}/source/libyuv")
-    c.chdir("{{ tmp }}/source")
+    if c.path("{{ tmp }}/source/libyuv").exists():
+        c.chdir("{{ tmp }}/source/libyuv")
+        c.run("git reset --hard")
+        c.run("git checkout main")
+        c.run("git pull")
+        c.run("git checkout {{ commit }}")
 
-    c.clone("https://chromium.googlesource.com/libyuv/libyuv", "--revision {{ commit }}")
+    else:
+        c.clean("{{ tmp }}/source/libyuv")
+        c.chdir("{{ tmp }}/source")
 
-    c.chdir("{{ tmp }}/source/libyuv")
+        c.clone("https://chromium.googlesource.com/libyuv/libyuv", minimal=False)
+        c.chdir("{{ tmp }}/source/libyuv")
+        c.run("git checkout {{ commit }}")
+
     c.patch("libyuv-noshared.diff")
 
 

--- a/tasks/libyuv.py
+++ b/tasks/libyuv.py
@@ -1,31 +1,22 @@
 from renpybuild.context import Context
 from renpybuild.task import task
 
-@task(kind="host", platforms="all")
-def download(c : Context):
 
+@task(kind="host", platforms="all")
+def download(c: Context):
     c.var("commit", "d23308a2a7442be8e559b1b471862fd7588d6a57")
 
-    if c.path("{{ tmp }}/source/libyuv").exists():
-        c.chdir("{{ tmp }}/source/libyuv")
-        c.run("git reset --hard")
-        c.run("git checkout main")
-        c.run("git pull")
-        c.run("git checkout {{ commit }}")
+    c.clean("{{ tmp }}/source/libyuv")
+    c.chdir("{{ tmp }}/source")
 
-    else:
+    c.clone("https://chromium.googlesource.com/libyuv/libyuv", "--revision {{ commit }}")
 
-        c.clean("{{ tmp }}/source/libyuv")
-        c.chdir("{{ tmp }}/source")
-
-        c.run("git clone https://chromium.googlesource.com/libyuv/libyuv")
-        c.chdir("{{ tmp }}/source/libyuv")
-        c.run("git checkout {{ commit }}")
-
+    c.chdir("{{ tmp }}/source/libyuv")
     c.patch("libyuv-noshared.diff")
 
+
 @task(platforms="all")
-def build(c : Context):
+def build(c: Context):
     c.clean()
 
     c.run("""

--- a/tasks/pyobjus.py
+++ b/tasks/pyobjus.py
@@ -15,23 +15,20 @@ def unpack(c: Context):
     c.clean()
 
     c.var("commit", commit)
-    c.run("git clone https://github.com/kivy/pyobjus pyobjus")
-    c.chdir("pyobjus")
+    c.clone("https://github.com/kivy/pyobjus", "--revision {{ commit }}")
 
-    c.run("git checkout  {{commit}}")
+    c.chdir("pyobjus")
     c.patch("pyobjus/ffi-h.diff")
 
 
 @task(kind="host-python")
 def host_unpack(c: Context):
-
     c.clean()
 
     c.var("commit", commit)
-    c.run("git clone https://github.com/kivy/pyobjus pyobjus")
-    c.chdir("pyobjus")
+    c.clone("https://github.com/kivy/pyobjus", "--revision {{ commit }}")
 
-    c.run("git checkout  {{commit}}")
+    c.chdir("pyobjus")
     c.patch("pyobjus/ffi-h.diff")
 
 

--- a/tasks/pyobjus.py
+++ b/tasks/pyobjus.py
@@ -15,9 +15,10 @@ def unpack(c: Context):
     c.clean()
 
     c.var("commit", commit)
-    c.clone("https://github.com/kivy/pyobjus", "--revision {{ commit }}")
-
+    c.clone("https://github.com/kivy/pyobjus", minimal=False)
     c.chdir("pyobjus")
+
+    c.run("git checkout {{ commit }}")
     c.patch("pyobjus/ffi-h.diff")
 
 
@@ -26,9 +27,10 @@ def host_unpack(c: Context):
     c.clean()
 
     c.var("commit", commit)
-    c.clone("https://github.com/kivy/pyobjus", "--revision {{ commit }}")
-
+    c.clone("https://github.com/kivy/pyobjus", minimal=False)
     c.chdir("pyobjus")
+
+    c.run("git checkout {{ commit }}")
     c.patch("pyobjus/ffi-h.diff")
 
 

--- a/tasks/python3.py
+++ b/tasks/python3.py
@@ -67,7 +67,7 @@ def patch_ios(c: Context):
 
 @task(kind="python", pythons="3", platforms="windows")
 def patch_windows(c: Context):
-    c.var("version", version)
+    c.var("version", win_version)
 
     c.chdir("cpython-mingw")
     c.patch("Python-{{ version }}/single-dllmain.diff")

--- a/tasks/python3.py
+++ b/tasks/python3.py
@@ -32,12 +32,11 @@ def unpack_windows(c: Context):
     c.var("version", win_version)
 
     if (c.root / "unpacked" / "cpython-mingw").exists():
-        c.run("git clone {{ c.root }}/unpacked/cpython-mingw")
+        c.var("repo", "{{ c.root }}/unpacked/cpython-mingw")
     else:
-        c.run("git clone https://github.com/msys2-contrib/cpython-mingw")
+        c.var("repo", "https://github.com/msys2-contrib/cpython-mingw")
 
-    c.chdir("cpython-mingw")
-    c.run("git checkout mingw-v{{ version }}")
+    c.clone("{{ repo }}", "--branch mingw-v{{ version }}")
 
 @task(kind="python", pythons="3", platforms="linux,mac,ios")
 def patch_posix(c: Context):
@@ -68,7 +67,7 @@ def patch_ios(c: Context):
 
 @task(kind="python", pythons="3", platforms="windows")
 def patch_windows(c: Context):
-    c.var("version", win_version)
+    c.var("version", version)
 
     c.chdir("cpython-mingw")
     c.patch("Python-{{ version }}/single-dllmain.diff")

--- a/tasks/toolchain.py
+++ b/tasks/toolchain.py
@@ -106,7 +106,8 @@ def emsdk(c: Context):
     c.var("emsdk_version", "5.0.2")
 
     c.clean("{{ cross }}")
-    c.run("git clone https://github.com/emscripten-core/emsdk/ {{cross}}")
+    c.clone("https://github.com/emscripten-core/emsdk/", directory="{{ cross }}")
+
     c.chdir("{{ cross }}")
     c.run("./emsdk install {{ emsdk_version }}")
     c.run("./emsdk activate {{ emsdk_version }}")


### PR DESCRIPTION
This PR adds specialised `Context.clone` method and applies it to all the places build system does the clone. That reduces download size a lot (about 99% for mingw-python case).

Use of `git clone --revision SHA` requieres git at least 2.49 which is not latest default for ubuntu and would also requiere
```
For Ubuntu, this PPA provides the latest stable upstream Git version

# add-apt-repository ppa:git-core/ppa
# apt update; apt install git
```
but libyuv and pyobjus are not that big, so that two repos could be reverted to use full clone.