### PR TITLE
Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This PR fixes the problem that on windows clone will set Windows line endlings on sh files to crlf those making it broken in linux context (WSL/container).