### PR TITLE
Make sure angle libs are copied.

### DIFF
--- a/tasks/angle.py
+++ b/tasks/angle.py
@@ -2,9 +2,8 @@ from renpybuild.context import Context
 from renpybuild.task import task
 
 
-@task(kind="arch", platforms="windows")
+@task(kind="arch", platforms="windows", always=True)
 def install(c: Context):
     c.run("install -d {{ dlpa }}")
     c.run("install {{ prebuilt }}/{{ c.arch}}/libGLESv2.dll {{ dlpa }}")
     c.run("install {{ prebuilt }}/{{ c.arch }}/libEGL.dll {{ dlpa }}")
-    c.run("install {{ prebuilt }}/{{ c.arch }}/d3dcompiler_47.dll {{ dlpa }}")


### PR DESCRIPTION
This PR does 2 things.
1. Makes sure angle dlls always copied during build, otherwise angle renderer can't initialize.
2. Removes d3dcompiler_47.dll because it should be always present on windows 10 or later.