### PR TITLE
Use macros magic to fixup `PyInit_` collisions.

### DIFF
--- a/renpybuild/run.py
+++ b/renpybuild/run.py
@@ -459,7 +459,7 @@ def build_environment(c):
 
     c.env("PKG_CONFIG", "pkg-config --static")
 
-    c.env("CFLAGS", "{{ CFLAGS }} -DRENPY_BUILD")
+    c.env("CFLAGS", "{{ CFLAGS }} -DRENPY_BUILD -DCYTHON_NO_PYINIT_EXPORT")
     c.env("CXXFLAGS", "{{ CFLAGS }}")
 
     if c.platform in ("mac", "ios"):

--- a/tasks/librenpy.py
+++ b/tasks/librenpy.py
@@ -27,25 +27,25 @@ def build(c: Context):
 
     modules = []
     sources = []
+    source_module = {}
 
     def read_setup(dn, suffix=""):
-
         with open(dn / ("Setup" + suffix)) as f:
-            for l in f:
-                l = l.partition("#")[0]
-                l = l.strip()
-
-                if not l:
+            for line in f:
+                line = line.partition("#")[0].strip()
+                if not line:
                     continue
-
-                parts = l.split()
-
-                modules.append(parts[0])
+                parts = line.split()
+                module_name = parts[0]
+                modules.append(module_name)
 
                 for i in parts[1:]:
                     if "libhydrogen" not in i:
                         i = i.replace("gen/", gen)
-                    sources.append(dn / i)
+
+                    source = dn / i
+                    sources.append(source)
+                    source_module[source] = module_name
 
     read_setup(c.renpy / "src")
     read_setup(c.root / "extensions")
@@ -76,10 +76,16 @@ def build(c: Context):
             c.var("src", source)
             c.var("object", object)
 
+            c.var("pyinit_define", "")
+            if module_name := source_module.get(source):
+                mangled = module_name.replace(".", "_")
+                short = module_name.rpartition(".")[-1]
+                c.var("pyinit_define", f"-DPyInit_{short}=PyInit_{mangled}")
+
             if ext == "c":
-                g.run("{{ CC }} {{ CFLAGS }} -c {{ src }} -o {{ object }}")
+                g.run("{{ CC }} {{ CFLAGS }} {{ pyinit_define }} -c {{ src }} -o {{ object }}")
             else:
-                g.run("{{ CXX }} {{ CXXFLAGS }} -c {{ src }} -o {{ object }}")
+                g.run("{{ CXX }} {{ CXXFLAGS }} {{ pyinit_define }} -c {{ src }} -o {{ object }}")
 
         c.generate("{{ runtime }}/librenpy_inittab.c", "inittab.c", modules=modules)
         g.run("{{ CC }} {{ CFLAGS }} -c inittab.c -o inittab.o")

--- a/tasks/pyjnius.py
+++ b/tasks/pyjnius.py
@@ -41,47 +41,12 @@ cdef JNIEnv *get_platform_jnienv():
 
     c.run("""cython jnius.pyx""")
 
-    c_fn = c.path("jnius.c")
-
-    parent_module = "jnius"
-    parent_module_identifier = "jnius"
-
-    with open(c_fn) as f:
-        ccode = f.read()
-    ccode = re.sub(r'Py_InitModule4\("([^"]+)"', 'Py_InitModule4("' + parent_module + '.\\1"', ccode)
-    ccode = re.sub(
-        r"^__Pyx_PyMODINIT_FUNC init",
-        "__Pyx_PyMODINIT_FUNC init" + parent_module_identifier + "_",
-        ccode,
-        0,
-        re.MULTILINE,
-    )  # Cython 0.28.2
-    ccode = re.sub(
-        r"^PyMODINIT_FUNC init", "PyMODINIT_FUNC init" + parent_module_identifier + "_", ccode, 0, re.MULTILINE
-    )  # Cython 0.25.2
-    ccode = re.sub(
-        r"^__Pyx_PyMODINIT_FUNC PyInit_",
-        "__Pyx_PyMODINIT_FUNC PyInit_" + parent_module_identifier + "_",
-        ccode,
-        0,
-        re.MULTILINE,
-    )  # Cython 0.28.2
-    ccode = re.sub(
-        r"^PyMODINIT_FUNC PyInit_", "PyMODINIT_FUNC PyInit_" + parent_module_identifier + "_", ccode, 0, re.MULTILINE
-    )  # Cython 0.25.2
-    with open(c_fn, "w") as f:
-        f.write(ccode)
-
     c.run("""install -d {{ pytmp }}/pyjnius/jnius""")
-    c.run("""install env.py  __init__.py  reflect.py  signatures.py {{ pytmp }}/pyjnius/jnius""")
+    c.run("""install env.py __init__.py reflect.py signatures.py {{ pytmp }}/pyjnius/jnius""")
     c.run("""install jnius.c {{ pytmp }}/pyjnius/""")
 
     with open(c.path("{{ pytmp }}/pyjnius/Setup"), "w") as f:
-        f.write(
-            c.expand("""\
-jnius.jnius jnius.c
-""")
-        )
+        f.write("jnius.jnius jnius.c\n")
 
 
 @task(kind="host", always=True)

--- a/tasks/pyobjus.py
+++ b/tasks/pyobjus.py
@@ -51,48 +51,12 @@ DEF PYOBJUS_CYTHON_3 = True
 
     c.run("""cython pyobjus.pyx""")
 
-    c_fn = c.path("pyobjus.c")
-
-    parent_module = "pyobjus"
-    parent_module_identifier = "pyobjus"
-
-    with open(c_fn) as f:
-        ccode = f.read()
-
-    ccode = re.sub(r'Py_InitModule4\("([^"]+)"', 'Py_InitModule4("' + parent_module + '.\\1"', ccode)
-    ccode = re.sub(
-        r"^__Pyx_PyMODINIT_FUNC init",
-        "__Pyx_PyMODINIT_FUNC init" + parent_module_identifier + "_",
-        ccode,
-        0,
-        re.MULTILINE,
-    )  # Cython 0.28.2
-    ccode = re.sub(
-        r"^PyMODINIT_FUNC init", "PyMODINIT_FUNC init" + parent_module_identifier + "_", ccode, 0, re.MULTILINE
-    )  # Cython 0.25.2
-    ccode = re.sub(
-        r"^__Pyx_PyMODINIT_FUNC PyInit_",
-        "__Pyx_PyMODINIT_FUNC PyInit_" + parent_module_identifier + "_",
-        ccode,
-        0,
-        re.MULTILINE,
-    )  # Cython 0.28.2
-    ccode = re.sub(
-        r"^PyMODINIT_FUNC PyInit_", "PyMODINIT_FUNC PyInit_" + parent_module_identifier + "_", ccode, 0, re.MULTILINE
-    )  # Cython 0.25.2
-    with open(c_fn, "w") as f:
-        f.write(ccode)
-
     c.run("""install -d {{ install }}/pyobjus""")
 
     c.run("""install pyobjus.c _runtime.h {{ install }}/pyobjus/""")
 
     with open(c.path("{{ install }}/pyobjus/Setup"), "w") as f:
-        f.write(
-            c.expand("""\
-pyobjus.pyobjus pyobjus.c
-""")
-        )
+        f.write("pyobjus.pyobjus pyobjus.c\n")
 
 
 @task(kind="host")


### PR DESCRIPTION
Instead of doing regex replaces on cython output in several places use `PyInit_short PyInit_mangled` macro. This makes `gen3` and `gen3-static` essentially the same, so in follow-up PR I will drop it.