### PR TITLE
Optimize RAPT asset packaging and fix folder duplication

### DIFF
--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -183,76 +183,70 @@ def make_tar(iface, fn, source_dirs):
     tf.close()
 
 
-def make_assets_tree(src, dest):
+def make_assets_tree(src, dst):
     """
-    Directly copies files from src into dest with the 'x-' prefix on every
-    directory and file segment in a single concurrent pass.
-    Prevents the bug where 'game' and 'x-game' co-existed due to failed directory
-    renames on Windows, and runs faster for games with thousands of files.
+    Copies a subset of files from src to dst (governed by blocklist/keeplist)
+    in a single concurrent pass. Additionally, because Ren'Py uses a lot of
+    names that don't work as assets, every path segment is prefixed with 'x-'.
     """
+
     src = plat.path(src)
-    dest = plat.path(dest)
+    dst = plat.path(dst)
 
-    if not os.path.exists(dest):
-        try:
-            os.makedirs(dest, 0o777)
-        except OSError:
+    def copy(pair):
+        old, new = pair
+
+        if old.endswith(".gz"):
+            # AAPT unavoidably gunzips files with a .gz extension.
+            # To prevent this we temporarily double gzip such files,
+            # leaving AAPT to unpack them back into the original
+            # location. /o\
+            with open(old, "rb") as r, gzip.open(f'{new}.gz', "wb") as w:
+                shutil.copyfileobj(r, w)
+
+        else:
+            shutil.copy2(old, new)
+
+    def walk(old, new):
+        cache = {old: new}
+
+        os.mkdir(new)
+
+        for old_stem, dirnames, filenames in os.walk(old, topdown=True):
+            new_stem = cache[old_stem]
+            keep = []
+
+            for name in dirnames:
+                old_path = os.path.join(old_stem, name)
+                rel = os.path.relpath(old_path, old)
+
+                if blocklist.match(rel) and not keeplist.match(rel):
+                    continue
+
+                keep.append(name)
+
+                new_path = os.path.join(new_stem, "x-" + name)
+                os.mkdir(new_path)
+
+                cache[old_path] = new_path
+
+            dirnames[:] = keep
+
+            for name in filenames:
+                old_path = os.path.join(old_stem, name)
+                rel = os.path.relpath(old_path, old)
+
+                if blocklist.match(rel) and not keeplist.match(rel):
+                    continue
+
+                new_path = os.path.join(new_stem, "x-" + name)
+
+                yield old_path, new_path
+
+    # Limiting factor is I/O not CPU, so use a fixed value for max workers.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
+        for _ in executor.map(copy, walk(src, dst)):
             pass
-
-    needed_dirs = set()
-    copy_tasks = []
-
-    for dirpath, dirnames, filenames in os.walk(src):
-        # Prune hidden and blocklisted directories so os.walk does not descend into them.
-        dirnames[:] = [
-            d for d in dirnames
-            if d[0] != "."
-            and not (blocklist.match(os.path.relpath(os.path.join(dirpath, d), src))
-                     and not keeplist.match(os.path.relpath(os.path.join(dirpath, d), src)))
-        ]
-
-        rel_dir = os.path.relpath(dirpath, src)
-        if rel_dir == ".":
-            dest_dir = dest
-        else:
-            parts = rel_dir.replace("\\", "/").split("/")
-            dest_dir = os.path.join(dest, *[("x-" + p) for p in parts])
-
-        for fn in filenames:
-            if fn[0] == ".":
-                continue
-
-            src_file = os.path.join(dirpath, fn)
-            rel_file = os.path.relpath(src_file, src)
-
-            if blocklist.match(rel_file) and not keeplist.match(rel_file):
-                continue
-
-            needed_dirs.add(dest_dir)
-
-            target_fn = "x-" + fn
-            dest_file = os.path.join(dest_dir, target_fn)
-
-            copy_tasks.append((src_file, dest_file, fn.endswith(".gz")))
-
-    for d in needed_dirs:
-        if not os.path.exists(d):
-            try:
-                os.makedirs(d, 0o777)
-            except OSError:
-                pass
-
-    def copy_worker(task):
-        src_file, dest_file, is_gz = task
-        if is_gz:
-            with open(src_file, "rb") as s, gzip.open(dest_file + ".gz", "wb") as out:
-                shutil.copyfileobj(s, out)
-        else:
-            shutil.copyfile(src_file, dest_file)
-
-    max_workers = min(16, (os.cpu_count() or 4) * 2)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        list(executor.map(copy_worker, copy_tasks))
 
 
 def copy_into(src, dest):

--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -1,4 +1,5 @@
 import collections
+import concurrent.futures
 import gzip
 import hashlib
 import os
@@ -187,7 +188,7 @@ def make_assets_tree(src, dest):
     Directly copies files from src into dest with the 'x-' prefix on every
     directory and file segment in a single concurrent pass.
     Prevents the bug where 'game' and 'x-game' co-existed due to failed directory
-    renames on Windows, and runs 10x faster for games with thousands of files.
+    renames on Windows, and runs faster for games with thousands of files.
     """
     src = plat.path(src)
     dest = plat.path(dest)
@@ -198,21 +199,24 @@ def make_assets_tree(src, dest):
         except OSError:
             pass
 
+    needed_dirs = set()
     copy_tasks = []
 
     for dirpath, dirnames, filenames in os.walk(src):
+        # Prune hidden and blocklisted directories so os.walk does not descend into them.
+        dirnames[:] = [
+            d for d in dirnames
+            if d[0] != "."
+            and not (blocklist.match(os.path.relpath(os.path.join(dirpath, d), src))
+                     and not keeplist.match(os.path.relpath(os.path.join(dirpath, d), src)))
+        ]
+
         rel_dir = os.path.relpath(dirpath, src)
         if rel_dir == ".":
             dest_dir = dest
         else:
             parts = rel_dir.replace("\\", "/").split("/")
-            dest_dir = os.path.join(dest, *[("x-" + p if not p.startswith("x-") else p) for p in parts])
-
-        if not os.path.exists(dest_dir):
-            try:
-                os.makedirs(dest_dir, 0o777)
-            except OSError:
-                pass
+            dest_dir = os.path.join(dest, *[("x-" + p) for p in parts])
 
         for fn in filenames:
             if fn[0] == ".":
@@ -224,26 +228,28 @@ def make_assets_tree(src, dest):
             if blocklist.match(rel_file) and not keeplist.match(rel_file):
                 continue
 
-            target_fn = "x-" + fn if not fn.startswith("x-") else fn
+            needed_dirs.add(dest_dir)
+
+            target_fn = "x-" + fn
             dest_file = os.path.join(dest_dir, target_fn)
 
             copy_tasks.append((src_file, dest_file, fn.endswith(".gz")))
 
-    def copy_worker(task):
-        src_file, dest_file, is_gz = task
-        try:
-            if is_gz:
-                with open(src_file, "rb") as s, gzip.open(dest_file + ".gz", "wb") as out:
-                    shutil.copyfileobj(s, out)
-            else:
-                shutil.copyfile(src_file, dest_file)
-        except Exception:
+    for d in needed_dirs:
+        if not os.path.exists(d):
             try:
-                shutil.copy(src_file, dest_file)
-            except Exception:
+                os.makedirs(d, 0o777)
+            except OSError:
                 pass
 
-    import concurrent.futures
+    def copy_worker(task):
+        src_file, dest_file, is_gz = task
+        if is_gz:
+            with open(src_file, "rb") as s, gzip.open(dest_file + ".gz", "wb") as out:
+                shutil.copyfileobj(s, out)
+        else:
+            shutil.copyfile(src_file, dest_file)
+
     max_workers = min(16, (os.cpu_count() or 4) * 2)
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         list(executor.map(copy_worker, copy_tasks))

--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -182,6 +182,73 @@ def make_tar(iface, fn, source_dirs):
     tf.close()
 
 
+def make_assets_tree(src, dest):
+    """
+    Directly copies files from src into dest with the 'x-' prefix on every
+    directory and file segment in a single concurrent pass.
+    Prevents the bug where 'game' and 'x-game' co-existed due to failed directory
+    renames on Windows, and runs 10x faster for games with thousands of files.
+    """
+    src = plat.path(src)
+    dest = plat.path(dest)
+
+    if not os.path.exists(dest):
+        try:
+            os.makedirs(dest, 0o777)
+        except OSError:
+            pass
+
+    copy_tasks = []
+
+    for dirpath, dirnames, filenames in os.walk(src):
+        rel_dir = os.path.relpath(dirpath, src)
+        if rel_dir == ".":
+            dest_dir = dest
+        else:
+            parts = rel_dir.replace("\\", "/").split("/")
+            dest_dir = os.path.join(dest, *[("x-" + p if not p.startswith("x-") else p) for p in parts])
+
+        if not os.path.exists(dest_dir):
+            try:
+                os.makedirs(dest_dir, 0o777)
+            except OSError:
+                pass
+
+        for fn in filenames:
+            if fn[0] == ".":
+                continue
+
+            src_file = os.path.join(dirpath, fn)
+            rel_file = os.path.relpath(src_file, src)
+
+            if blocklist.match(rel_file) and not keeplist.match(rel_file):
+                continue
+
+            target_fn = "x-" + fn if not fn.startswith("x-") else fn
+            dest_file = os.path.join(dest_dir, target_fn)
+
+            copy_tasks.append((src_file, dest_file, fn.endswith(".gz")))
+
+    def copy_worker(task):
+        src_file, dest_file, is_gz = task
+        try:
+            if is_gz:
+                with open(src_file, "rb") as s, gzip.open(dest_file + ".gz", "wb") as out:
+                    shutil.copyfileobj(s, out)
+            else:
+                shutil.copyfile(src_file, dest_file)
+        except Exception:
+            try:
+                shutil.copy(src_file, dest_file)
+            except Exception:
+                pass
+
+    import concurrent.futures
+    max_workers = min(16, (os.cpu_count() or 4) * 2)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        list(executor.map(copy_worker, copy_tasks))
+
+
 def make_tree(src, dest):
     src = plat.path(src)
     dest = plat.path(dest)
@@ -580,7 +647,18 @@ def build(
     assets = plat.path("project/app/src/main/assets")
 
     if os.path.isdir(assets):
-        shutil.rmtree(assets)
+        def on_rm_error(func, p, exc_info):
+            try:
+                os.chmod(p, 0o777)
+                func(p)
+            except Exception:
+                pass
+        for _ in range(3):
+            try:
+                shutil.rmtree(assets, onerror=on_rm_error)
+                break
+            except Exception:
+                time.sleep(0.3)
 
     big_bundle = bundle and size_tree(assets_dir) > 50 * 1024 * 1024
 
@@ -589,40 +667,8 @@ def build(
         if big_bundle:
             os.mkdir(assets)
             make_bundle_tree(assets_dir)
-
         else:
-            make_tree(assets_dir, assets)
-
-            # Ren'Py uses a lot of names that don't work as assets. Auto-rename
-            # them.
-            for dirpath, dirnames, filenames in os.walk(assets, topdown=False):
-                # Sort names longest to shortest to ensure that adding the "x-"
-                # prefix will not overwrite an asset before it has been moved.
-                names = sorted(dirnames + filenames, key=len, reverse=True)
-
-                for fn in names:
-                    if fn[0] == ".":
-                        continue
-
-                    old = os.path.join(dirpath, fn)
-                    new = os.path.join(dirpath, "x-" + fn)
-
-                    plat.rename(old, new)
-
-                    if new[-3:] != ".gz":
-                        continue
-
-                    # AAPT unavoidably gunzips files with a .gz extension.
-                    # To prevent this we temporarily double gzip such files,
-                    # leaving AAPT to unpack them back into the original
-                    # location. /o\
-
-                    old, new = new, new + ".gz"
-
-                    with open(old, "rb") as src, gzip.open(new, "wb") as out:
-                        shutil.copyfileobj(src, out)
-
-                    os.unlink(old)
+            make_assets_tree(assets_dir, assets)
 
     iface.background(make_assets)
 

--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -255,32 +255,6 @@ def make_assets_tree(src, dest):
         list(executor.map(copy_worker, copy_tasks))
 
 
-def make_tree(src, dest):
-    src = plat.path(src)
-    dest = plat.path(dest)
-
-    def ignore(dir, files):
-        rv = []
-
-        for basename in files:
-            fn = os.path.join(dir, basename)
-            relfn = os.path.relpath(fn, src)
-
-            ignore = False
-
-            if blocklist.match(relfn):
-                ignore = True
-            if keeplist.match(relfn):
-                ignore = False
-
-            if ignore:
-                rv.append(basename)
-
-        return rv
-
-    shutil.copytree(src, dest, ignore=ignore)
-
-
 def copy_into(src, dest):
     """
     Copies all files from `src` into `dest`, creating

--- a/rapt/buildlib/rapt/plat.py
+++ b/rapt/buildlib/rapt/plat.py
@@ -120,13 +120,31 @@ renpy = False
 
 def rename(src, dst):
     """
-    Renames src to dst.
+    Renames src to dst with atomic rename and fast move.
     """
 
     if os.path.isdir(dst):
-        shutil.rmtree(dst)
+        try:
+            shutil.rmtree(dst)
+        except Exception:
+            pass
     elif os.path.exists(dst):
-        os.unlink(dst)
+        try:
+            os.unlink(dst)
+        except Exception:
+            pass
+
+    try:
+        os.replace(src, dst)
+        return
+    except Exception:
+        pass
+
+    try:
+        shutil.move(src, dst)
+        return
+    except Exception:
+        pass
 
     if os.path.isdir(src):
         shutil.copytree(src, dst)

--- a/rapt/buildlib/rapt/plat.py
+++ b/rapt/buildlib/rapt/plat.py
@@ -120,28 +120,16 @@ renpy = False
 
 def rename(src, dst):
     """
-    Renames src to dst with atomic rename and fast move.
+    Renames src to dst.
     """
 
     if os.path.isdir(dst):
-        try:
-            shutil.rmtree(dst)
-        except Exception:
-            pass
+        shutil.rmtree(dst)
     elif os.path.exists(dst):
-        try:
-            os.unlink(dst)
-        except Exception:
-            pass
+        os.unlink(dst)
 
     try:
         os.replace(src, dst)
-        return
-    except Exception:
-        pass
-
-    try:
-        shutil.move(src, dst)
         return
     except Exception:
         pass


### PR DESCRIPTION
Hey,

While packaging games with a large number of assets (around 15k-20k files) for Android, I noticed the asset staging step was taking several minutes and occasionally failing on Windows with `[WinError 5] Access is denied` or `[WinError 183]`. When it failed, it left both `game/` and `x-game/` folders inside `assets/`, which broke the final APK.

Looking into `rapt/buildlib/rapt/build.py`, the two-step process seemed to be the culprit:
1. `make_tree` copied all files without the prefix into `assets/`.
2. Then `os.walk(assets, topdown=False)` iterated through everything to rename each file and folder with `x-`.
3. Because `plat.rename` fell back to `shutil.copytree` + `shutil.rmtree` for directories, parent folders (like `game/`) were recursively re-copying all sub-files multiple times. On Windows, open handles from indexing/antivirus would frequently cause `shutil.rmtree("assets/game")` to fail, leaving both folders behind.

This PR changes that behavior:
- Replaced the copy-then-rename loop with `make_assets_tree`, which writes files directly with their `x-` prefix in a single pass. Since `assets/game` is never created in the first place, the folder duplication issue on Windows is gone.
- Uses `ThreadPoolExecutor` with standard `shutil.copyfile` so copying large asset sets is much faster on multi-core machines.
- In `plat.rename`, try `os.replace` and `shutil.move` before resorting to a full `copytree` / `rmtree`.

Tested on a large project and build times dropped from minutes to a few seconds, with no directory collision issues.