### PR TITLE
More rapt file staging improvements

### DIFF
--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -183,6 +183,30 @@ def make_tar(iface, fn, source_dirs):
     tf.close()
 
 
+def copy_into(src, dest):
+    """
+    Copies all files from `src` into `dest`, creating
+    directories that do not exist.
+    """
+
+    if not os.path.exists(src):
+        return
+
+    if os.path.isdir(src):
+        if not os.path.isdir(dest):
+            os.mkdir(dest, 0o777)
+
+        for i in os.listdir(src):
+            copy_into(
+                os.path.join(src, i),
+                os.path.join(dest, i),
+            )
+
+        return
+
+    shutil.copy2(src, dest)
+
+
 def make_assets_tree(src, dst):
     """
     Copies a subset of files from src to dst (governed by blocklist/keeplist)
@@ -247,30 +271,6 @@ def make_assets_tree(src, dst):
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
         for _ in executor.map(copy, walk(src, dst)):
             pass
-
-
-def copy_into(src, dest):
-    """
-    Copies all files from `src` into `dest`, creating
-    directories that do not exist.
-    """
-
-    if not os.path.exists(src):
-        return
-
-    if os.path.isdir(src):
-        if not os.path.isdir(dest):
-            os.mkdir(dest, 0o777)
-
-        for i in os.listdir(src):
-            copy_into(
-                os.path.join(src, i),
-                os.path.join(dest, i),
-            )
-
-        return
-
-    shutil.copy2(src, dest)
 
 
 MAX_SIZE = 1000000000

--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -217,13 +217,7 @@ def make_assets_tree(src, dst):
     src = plat.path(src)
     dst = plat.path(dst)
 
-    drop = blocklist.match
-    keep = keeplist.match
-
     copy2 = shutil.copy2
-    join = os.path.join
-    mkdir = os.mkdir
-    relpath = os.path.relpath
 
     def copy(pair):
         old, new = pair
@@ -240,6 +234,21 @@ def make_assets_tree(src, dst):
             copy2(old, new)
 
     def walk(old, new):
+        drop = blocklist.match
+        keep = keeplist.match
+
+        mkdir = os.mkdir
+        relpath = os.path.relpath
+        sep = os.sep
+
+        # join: Faster than os.path.join for our purposes.
+        join = lambda a, b: f"{a}{sep}{b}"
+
+        # Special case the top-level iteration where rel_path='.', then
+        # replace with normal join function in subsequent iterations.
+        # join1: ignore 1st arg
+        join1 = lambda a, b: b
+
         cache = {old: new}
 
         mkdir(new)
@@ -251,7 +260,7 @@ def make_assets_tree(src, dst):
             visit = []
 
             for name in dirnames:
-                rel_path = join(rel_stem, name)
+                rel_path = join1(rel_stem, name)
 
                 if drop(rel_path) and not keep(rel_path):
                     continue
@@ -267,7 +276,7 @@ def make_assets_tree(src, dst):
             dirnames[:] = visit
 
             for name in filenames:
-                rel_path = join(rel_stem, name)
+                rel_path = join1(rel_stem, name)
 
                 if drop(rel_path) and not keep(rel_path):
                     continue
@@ -276,6 +285,8 @@ def make_assets_tree(src, dst):
                 new_path = join(new_stem, f"x-{name}")
 
                 yield old_path, new_path
+
+            join1 = join
 
     # Limiting factor is I/O not CPU, so use a fixed value for max workers.
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:

--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -119,9 +119,8 @@ def render(always, template, dest, **kwargs):
     template = environment.get_template(template)
     text = template.render(**kwargs)
 
-    f = open(dest, "wb")
-    f.write(text.encode("utf-8"))
-    f.close()
+    with open(dest, "wb") as f:
+        f.write(text.encode("utf-8"))
 
 
 def make_tar(iface, fn, source_dirs):
@@ -560,7 +559,8 @@ def copy_project(update_always=False):
         fn = plat.path(fn)
 
         if os.path.exists(fn):
-            return open(fn).read().strip()
+            with open(fn) as f:
+                return f.read().strip()
         else:
             return None
 

--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -217,10 +217,18 @@ def make_assets_tree(src, dst):
     src = plat.path(src)
     dst = plat.path(dst)
 
+    drop = blocklist.match
+    keep = keeplist.match
+
+    copy2 = shutil.copy2
+    join = os.path.join
+    mkdir = os.mkdir
+    relpath = os.path.relpath
+
     def copy(pair):
         old, new = pair
 
-        if old.endswith(".gz"):
+        if old[-3:] == ".gz":
             # AAPT unavoidably gunzips files with a .gz extension.
             # To prevent this we temporarily double gzip such files,
             # leaving AAPT to unpack them back into the original
@@ -229,41 +237,43 @@ def make_assets_tree(src, dst):
                 shutil.copyfileobj(r, w)
 
         else:
-            shutil.copy2(old, new)
+            copy2(old, new)
 
     def walk(old, new):
         cache = {old: new}
 
-        os.mkdir(new)
+        mkdir(new)
 
-        for old_stem, dirnames, filenames in os.walk(old, topdown=True):
+        for old_stem, dirnames, filenames in os.walk(old):
             new_stem = cache[old_stem]
-            keep = []
+            rel_stem = relpath(old_stem, old)
+
+            visit = []
 
             for name in dirnames:
-                old_path = os.path.join(old_stem, name)
-                rel = os.path.relpath(old_path, old)
+                rel_path = join(rel_stem, name)
 
-                if blocklist.match(rel) and not keeplist.match(rel):
+                if drop(rel_path) and not keep(rel_path):
                     continue
 
-                keep.append(name)
-
-                new_path = os.path.join(new_stem, "x-" + name)
-                os.mkdir(new_path)
+                old_path = join(old_stem, name)
+                new_path = join(new_stem, f"x-{name}")
 
                 cache[old_path] = new_path
+                visit.append(name)
 
-            dirnames[:] = keep
+                mkdir(new_path)
+
+            dirnames[:] = visit
 
             for name in filenames:
-                old_path = os.path.join(old_stem, name)
-                rel = os.path.relpath(old_path, old)
+                rel_path = join(rel_stem, name)
 
-                if blocklist.match(rel) and not keeplist.match(rel):
+                if drop(rel_path) and not keep(rel_path):
                     continue
 
-                new_path = os.path.join(new_stem, "x-" + name)
+                old_path = join(old_stem, name)
+                new_path = join(new_stem, f"x-{name}")
 
                 yield old_path, new_path
 

--- a/rapt/buildlib/rapt/build.py
+++ b/rapt/buildlib/rapt/build.py
@@ -1,4 +1,3 @@
-import collections
 import concurrent.futures
 import gzip
 import hashlib
@@ -299,59 +298,108 @@ MAX_SIZE = 1000000000
 
 def make_bundle_tree(src):
     src = plat.path(src)
-    sizes = collections.defaultdict(int)
 
-    targets = [
-        plat.path("project/ff1/src/main/assets"),
-        plat.path("project/ff2/src/main/assets"),
-        plat.path("project/ff3/src/main/assets"),
-        plat.path("project/ff4/src/main/assets"),
-    ]
+    dst = []
+    vol = {}
 
-    # Write at least one file in each assets directory, to make sure that
-    # all exist.
-    for i in targets:
-        if os.path.isdir(i):
-            shutil.rmtree(i)
+    rename = plat.rename
+
+    # Initialise an assets directory for each bundle and add a test
+    # file to make sure they exist and are writable.
+    for i in range(1, 5):
+        root = plat.path(f"project/ff{i}/src/main/assets")
+
+        if os.path.isdir(root):
+            shutil.rmtree(root)
 
         try:
-            os.makedirs(i, 0o777)
+            os.makedirs(root, 0o777)
         except Exception:
             pass
 
-        with open(os.path.join(i, "00_pack.txt"), "w") as f:
+        with open(os.path.join(root, "00_pack.txt"), "w") as f:
             f.write("Shiro was here.\n")
 
-    for dirpath, _, filenames in os.walk(src):
-        for fn in filenames:
-            if fn[0] == ".":
-                continue
+        dst.append(root)
+        vol[root] = 0
 
-            old = os.path.join(dirpath, fn)
-            size = os.path.getsize(old)
+    def move(pair):
+        old, new = pair
 
-            matchfn = os.path.relpath(old, src)
+        rename(old, new)
 
-            if blocklist.match(matchfn) and not keeplist.match(matchfn):
-                continue
+    def walk(old, new):
+        drop = blocklist.match
+        keep = keeplist.match
 
-            for target in targets:
-                if sizes[target] + size <= MAX_SIZE:
-                    break
-            else:
-                raise Exception("Game too big for bundle, or single file > 500MB.")
+        getsize = os.path.getsize
+        makedirs = os.makedirs
+        relpath = os.path.relpath
+        sep = os.sep
 
-            sizes[target] += size
+        # join: Faster than os.path.join for our purposes.
+        join = lambda a, b: f"{a}{sep}{b}"
 
-            new = os.path.join(target, os.path.relpath(dirpath, src), fn)
-            newdir = os.path.join(target, os.path.relpath(dirpath, src))
+        # Special case the top-level iteration where rel_path='.', then
+        # replace with normal join function in subsequent iterations.
+        # join1: ignore 1st arg
+        # join2: ignore 2nd arg
+        join1 = lambda a, b: b
+        join2 = lambda a, b: a
 
-            try:
-                os.makedirs(newdir, 0o777)
-            except Exception:
-                pass
+        cache = set(new)
+        cache_add = cache.add
 
-            plat.rename(old, new)
+        for old_stem, dirnames, filenames in os.walk(old):
+            rel_stem = relpath(old_stem, old)
+
+            visit = []
+
+            for name in dirnames:
+                rel_path = join1(rel_stem, name)
+
+                if drop(rel_path) and not keep(rel_path):
+                    continue
+
+                visit.append(name)
+
+            dirnames[:] = visit
+
+            for name in filenames:
+                rel_path = join1(rel_stem, name)
+
+                if drop(rel_path) and not keep(rel_path):
+                    continue
+
+                old_path = join(old_stem, name)
+                old_size = getsize(old_path)
+
+                threshold = MAX_SIZE - old_size
+
+                for new_root in new:
+                    if vol[new_root] <= threshold:
+                        break
+                else:
+                    raise Exception("Game too big for bundle, or single file > 1 GB.")
+
+                vol[new_root] += old_size
+
+                new_stem = join2(new_root, rel_stem)
+
+                if new_stem not in cache:
+                    makedirs(new_stem)
+                    cache_add(new_stem)
+
+                new_path = join(new_stem, name)
+
+                yield old_path, new_path
+
+            join1 = join2 = join
+
+    # Limiting factor is I/O not CPU, so use a fixed value for max workers.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
+        for _ in executor.map(move, walk(src, dst)):
+            pass
 
 
 def join_and_check(base, sub):


### PR DESCRIPTION
Follow up to #211.

Optimises a few things, fixes an issue processing the top-level directory, and applies the same approach used in `make_assets_tree` to `make_bundle_tree`. The commit messages and comments should, I hope, cover everything in sufficient detail.

~~Not fully tested yet, but the bits I have are doing what I believe they're meant to. Might need someone else to test the bundle part, not sure yet.~~